### PR TITLE
StyleCop linting

### DIFF
--- a/src/explorer.api/explorer.api.csproj
+++ b/src/explorer.api/explorer.api.csproj
@@ -4,5 +4,12 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 
 </Project>

--- a/src/explorer.api/explorer.api.csproj
+++ b/src/explorer.api/explorer.api.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CodeAnalysisRuleSet>../stylecop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <AdditionalFiles Include="../stylecop.json" />
   </ItemGroup>
-
 
 </Project>

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "$docs": "// https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md",
+  "settings": {
+  }
+}

--- a/src/stylecop.ruleset
+++ b/src/stylecop.ruleset
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Sample rule set" Description="Sample rule set illustrating customizing StyleCopAnalyzer rule severity" ToolsVersion="14.0">
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Action = None | Info | Warning | Error -->
+    <Rule Id="SA1600" Action="None" /> <!-- Elements should be documented --> <!-- this is disabled because there are similar warnings produced by the compiler -->
+  </Rules>
+</RuleSet>


### PR DESCRIPTION
I added the required configuration for linting using [StyleCop Analyzers](https://github.com/DotNetAnalyzers/StyleCopAnalyzers). This will need to be fine tuned using the included settings files, but I think that this could be done separately, after we decide which linting rules are useful for us and which not. Please notice that I did not fix yet the linting issues.