### PR TITLE
Quick fix for launch.json after project renaming

### DIFF
--- a/src/explorer.api/.vscode/launch.json
+++ b/src/explorer.api/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/Explorer.dll",
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/explorer.api.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,


### PR DESCRIPTION
This is just a quick fix - the program name in the launch.json needed to be updated following the recent renaming. 