### PR TITLE
Reference Aircloak project from tests

### DIFF
--- a/tests/explorer.api.tests/explorer.api.tests.csproj
+++ b/tests/explorer.api.tests/explorer.api.tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\explorer.api\explorer.api.csproj" />
+    <ProjectReference Include="..\..\src\aircloak\aircloak.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Aircloak.JsonApi project was used
in a test, but the project in which the
API is defined was not referenced.