### PR TITLE
Daniel/refactor explorer

### DIFF
--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -92,10 +92,18 @@
                 var metrics = explorer.ExploreMetrics
                     .Select(m => new ExploreResult.Metric(m.Name, m.Metric));
 
-                return Ok(new ExploreResult(
+                var result = new ExploreResult(
                             explorer.ExplorationGuid,
                             exploreStatus,
-                            metrics));
+                            metrics);
+
+                if (exploreStatus == ExploreResult.ExploreStatus.Complete ||
+                    exploreStatus == ExploreResult.ExploreStatus.Error)
+                {
+                    _ = Explorers.TryRemove(exploreId, out _);
+                }
+
+                return Ok(result);
             }
             else
             {

--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -78,9 +78,15 @@
             {
                 var exploreStatus = explorer.Completion().Status switch
                 {
+                    TaskStatus.Canceled => ExploreResult.ExploreStatus.Complete,
+                    TaskStatus.Created => ExploreResult.ExploreStatus.New,
+                    TaskStatus.Faulted => ExploreResult.ExploreStatus.Error,
                     TaskStatus.RanToCompletion => ExploreResult.ExploreStatus.Complete,
                     TaskStatus.Running => ExploreResult.ExploreStatus.Processing,
-                    _ => ExploreResult.ExploreStatus.Error,
+                    TaskStatus.WaitingForActivation => ExploreResult.ExploreStatus.New,
+                    TaskStatus.WaitingToRun => ExploreResult.ExploreStatus.New,
+                    TaskStatus.WaitingForChildrenToComplete => ExploreResult.ExploreStatus.Processing,
+                    var status => throw new System.Exception("Unexpected TaskStatus: '{status}'."),
                 };
 
                 var metrics = explorer.ExploreMetrics

--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -76,7 +76,7 @@
         {
             if (Explorers.TryGetValue(exploreId, out var explorer))
             {
-                var exploreStatus = explorer.Completion().Status switch
+                var exploreStatus = explorer.Status switch
                 {
                     TaskStatus.Canceled => ExploreResult.ExploreStatus.Complete,
                     TaskStatus.Created => ExploreResult.ExploreStatus.New,
@@ -147,13 +147,7 @@
                 return null;
             }
 
-            var explorer = new ColumnExplorer();
-            foreach (var component in components)
-            {
-                explorer.Spawn(component);
-            }
-
-            return explorer;
+            return new ColumnExplorer(components);
         }
     }
 }

--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -1,6 +1,7 @@
 ﻿namespace Explorer.Api.Controllers
 {
     using System.Collections.Concurrent;
+    using System.Linq;
     using System.Net.Mime;
     using System.Threading.Tasks;
 
@@ -82,10 +83,13 @@
                     _ => ExploreResult.ExploreStatus.Error,
                 };
 
+                var metrics = explorer.ExploreMetrics
+                    .Select(m => new ExploreResult.Metric(m.Name, m.Metric));
+
                 return Ok(new ExploreResult(
                             explorer.ExplorationGuid,
                             exploreStatus,
-                            explorer.ExploreMetrics));
+                            metrics));
             }
             else
             {

--- a/src/explorer.api/Explorers/AircloakQueryResolver.cs
+++ b/src/explorer.api/Explorers/AircloakQueryResolver.cs
@@ -5,7 +5,6 @@ namespace Explorer
 
     using Aircloak.JsonApi;
     using Aircloak.JsonApi.ResponseTypes;
-    using Explorer.Api.Models;
 
     internal class AircloakQueryResolver : IQueryResolver
     {
@@ -21,7 +20,7 @@ namespace Explorer
 
         public async Task<QueryResult<TResult>> ResolveQuery<TResult>(IQuerySpec<TResult> query, TimeSpan timeout)
         {
-            return await ApiClient.Query<TResult>(
+            return await ApiClient.Query(
                 DataSourceName,
                 query,
                 timeout);

--- a/src/explorer.api/Explorers/AircloakQueryResolver.cs
+++ b/src/explorer.api/Explorers/AircloakQueryResolver.cs
@@ -1,0 +1,30 @@
+namespace Explorer
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Aircloak.JsonApi;
+    using Aircloak.JsonApi.ResponseTypes;
+    using Explorer.Api.Models;
+
+    internal class AircloakQueryResolver : IQueryResolver
+    {
+        public AircloakQueryResolver(JsonApiClient apiClient, string dataSourceName)
+        {
+            ApiClient = apiClient;
+            DataSourceName = dataSourceName;
+        }
+
+        public string DataSourceName { get; }
+
+        public JsonApiClient ApiClient { get; }
+
+        public async Task<QueryResult<TResult>> ResolveQuery<TResult>(IQuerySpec<TResult> query, TimeSpan timeout)
+        {
+            return await ApiClient.Query<TResult>(
+                DataSourceName,
+                query,
+                timeout);
+        }
+    }
+}

--- a/src/explorer.api/Explorers/BoolColumnExplorer.cs
+++ b/src/explorer.api/Explorers/BoolColumnExplorer.cs
@@ -29,7 +29,7 @@ namespace Explorer
             var suppressedValueCount = distinctValues.ResultRows.Sum(row =>
                     row.ColumnValue.IsSuppressed ? row.Count : 0);
 
-            PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
+            PublishMetric(new UntypedMetric(name: "suppressed_values", metric: suppressedValueCount));
 
             var totalValueCount = distinctValues.ResultRows.Sum(row => row.Count);
 
@@ -40,7 +40,7 @@ namespace Explorer
                     $"Total value count for {TableName}, {ColumnName} is zero.");
             }
 
-            PublishMetric(new ExploreResult.Metric(name: "total_count", value: totalValueCount));
+            PublishMetric(new UntypedMetric(name: "total_count", metric: totalValueCount));
 
             var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
 
@@ -54,7 +54,7 @@ namespace Explorer
                     row.Count,
                 };
 
-            PublishMetric(new ExploreResult.Metric(name: "top_distinct_values", value: distinctValueCounts));
+            PublishMetric(new UntypedMetric(name: "top_distinct_values", metric: distinctValueCounts));
         }
     }
 }

--- a/src/explorer.api/Explorers/BoolColumnExplorer.cs
+++ b/src/explorer.api/Explorers/BoolColumnExplorer.cs
@@ -4,10 +4,9 @@ namespace Explorer
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi.ResponseTypes;
     using Explorer.Queries;
 
-    internal class BoolColumnExplorer : ExplorerImpl
+    internal class BoolColumnExplorer : ExplorerBase
     {
         public BoolColumnExplorer(IQueryResolver queryResolver, string tableName, string columnName)
             : base(queryResolver)

--- a/src/explorer.api/Explorers/BoolColumnExplorer.cs
+++ b/src/explorer.api/Explorers/BoolColumnExplorer.cs
@@ -16,9 +16,9 @@ namespace Explorer
             ColumnName = columnName;
         }
 
-        public string TableName { get; set; }
+        private string TableName { get; }
 
-        public string ColumnName { get; set; }
+        private string ColumnName { get; }
 
         public override async Task Explore()
         {

--- a/src/explorer.api/Explorers/BoolColumnExplorer.cs
+++ b/src/explorer.api/Explorers/BoolColumnExplorer.cs
@@ -1,33 +1,35 @@
 namespace Explorer
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi;
     using Aircloak.JsonApi.ResponseTypes;
-    using Explorer.Api.Models;
     using Explorer.Queries;
 
     internal class BoolColumnExplorer : ExplorerImpl
     {
-        public BoolColumnExplorer(JsonApiClient apiClient, ExploreParams exploreParams)
-            : base(apiClient, exploreParams)
+        public BoolColumnExplorer(IQueryResolver queryResolver, string tableName, string columnName)
+            : base(queryResolver)
         {
-            ExploreMetrics = Array.Empty<ExploreResult.Metric>();
+            TableName = tableName;
+            ColumnName = columnName;
         }
 
-        public IEnumerable<ExploreResult.Metric> ExploreMetrics { get; set; }
+        public string TableName { get; set; }
+
+        public string ColumnName { get; set; }
 
         public override async Task Explore()
         {
             var distinctValues = await ResolveQuery<DistinctColumnValues.BoolResult>(
-                new DistinctColumnValues(ExploreParams.TableName, ExploreParams.ColumnName),
+                new DistinctColumnValues(TableName, ColumnName),
                 timeout: TimeSpan.FromMinutes(2));
 
             var suppressedValueCount = distinctValues.ResultRows.Sum(row =>
                     row.ColumnValue.IsSuppressed ? row.Count : 0);
+
+            PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
 
             var totalValueCount = distinctValues.ResultRows.Sum(row => row.Count);
 
@@ -35,8 +37,10 @@ namespace Explorer
             if (totalValueCount == 0)
             {
                 throw new Exception(
-                    $"Total value count for {ExploreParams.TableName}, {ExploreParams.ColumnName} is zero.");
+                    $"Total value count for {TableName}, {ColumnName} is zero.");
             }
+
+            PublishMetric(new ExploreResult.Metric(name: "total_count", value: totalValueCount));
 
             var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
 
@@ -51,8 +55,6 @@ namespace Explorer
                 };
 
             PublishMetric(new ExploreResult.Metric(name: "top_distinct_values", value: distinctValueCounts));
-            PublishMetric(new ExploreResult.Metric(name: "total_count", value: totalValueCount));
-            PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
         }
     }
 }

--- a/src/explorer.api/Explorers/ColumnExplorer.cs
+++ b/src/explorer.api/Explorers/ColumnExplorer.cs
@@ -1,26 +1,18 @@
 namespace Explorer
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
     internal class ColumnExplorer
     {
-        private readonly ConcurrentStack<ExploreResult.Metric> exploreResults;
-
         private readonly Dictionary<Type, Task> childTasks;
 
         private readonly Dictionary<Type, ExplorerImpl> childExplorers;
 
-        private readonly ConcurrentDictionary<string, ExploreResult.Metric> exploreMetrics;
-
         public ColumnExplorer()
         {
             ExplorationGuid = Guid.NewGuid();
-
-            exploreResults = new ConcurrentStack<ExploreResult.Metric>();
-            exploreMetrics = new ConcurrentDictionary<string, ExploreResult.Metric>();
 
             childTasks = new Dictionary<Type, Task>();
             childExplorers = new Dictionary<Type, ExplorerImpl>();
@@ -28,7 +20,7 @@ namespace Explorer
 
         public Guid ExplorationGuid { get; }
 
-        public IEnumerable<ExploreResult.Metric> ExploreMetrics
+        public IEnumerable<IExploreMetric> ExploreMetrics
         {
             get
             {

--- a/src/explorer.api/Explorers/ColumnExplorer.cs
+++ b/src/explorer.api/Explorers/ColumnExplorer.cs
@@ -5,10 +5,6 @@ namespace Explorer
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi;
-    using Aircloak.JsonApi.ResponseTypes;
-    using Explorer.Api.Models;
-
     internal class ColumnExplorer
     {
         private readonly ConcurrentStack<ExploreResult.Metric> exploreResults;
@@ -56,45 +52,6 @@ namespace Explorer
             var exploreTask = Task.Run(explorerImpl.Explore);
             childExplorers.Add(explorerImpl.GetType(), explorerImpl);
             childTasks.Add(explorerImpl.GetType(), exploreTask);
-        }
-    }
-
-    internal abstract class ExplorerImpl
-    {
-        private readonly ConcurrentBag<ExploreResult.Metric> metrics;
-
-        protected ExplorerImpl(JsonApiClient apiClient, ExploreParams exploreParams)
-        {
-            ApiClient = apiClient;
-            ExploreParams = exploreParams;
-
-            metrics = new ConcurrentBag<ExploreResult.Metric>();
-        }
-
-        public ExploreResult.Metric[] Metrics
-        {
-            get => metrics.ToArray();
-        }
-
-        public ExploreParams ExploreParams { get; }
-
-        public JsonApiClient ApiClient { get; }
-
-        public abstract Task Explore();
-
-        protected void PublishMetric(ExploreResult.Metric metric)
-        {
-            metrics.Add(metric);
-        }
-
-        protected async Task<QueryResult<TResult>> ResolveQuery<TResult>(
-            IQuerySpec<TResult> query,
-            TimeSpan timeout)
-        {
-            return await ApiClient.Query<TResult>(
-                ExploreParams.DataSourceName,
-                query,
-                timeout);
         }
     }
 }

--- a/src/explorer.api/Explorers/Exploration.cs
+++ b/src/explorer.api/Explorers/Exploration.cs
@@ -5,18 +5,18 @@ namespace Explorer
     using System.Linq;
     using System.Threading.Tasks;
 
-    internal class ColumnExplorer
+    internal class Exploration
     {
         private readonly List<Task> childTasks;
 
-        private readonly List<ExplorerImpl> childExplorers;
+        private readonly List<ExplorerBase> childExplorers;
 
-        public ColumnExplorer(IEnumerable<ExplorerImpl> explorerImpls)
+        public Exploration(IEnumerable<ExplorerBase> explorerImpls)
         {
             ExplorationGuid = Guid.NewGuid();
 
             childTasks = new List<Task>();
-            childExplorers = new List<ExplorerImpl>();
+            childExplorers = new List<ExplorerBase>();
 
             foreach (var impl in explorerImpls)
             {
@@ -35,7 +35,7 @@ namespace Explorer
 
         public TaskStatus Status => Completion.Status;
 
-        private void Spawn(ExplorerImpl explorerImpl)
+        private void Spawn(ExplorerBase explorerImpl)
         {
             var exploreTask = Task.Run(explorerImpl.Explore);
             childExplorers.Add(explorerImpl);

--- a/src/explorer.api/Explorers/ExplorerException.cs
+++ b/src/explorer.api/Explorers/ExplorerException.cs
@@ -1,0 +1,27 @@
+namespace Explorer
+{
+    [System.Serializable]
+    public class ExplorerException : System.Exception
+    {
+        public ExplorerException()
+        {
+        }
+
+        public ExplorerException(string message)
+        : base(message)
+        {
+        }
+
+        public ExplorerException(string message, System.Exception inner)
+        : base(message, inner)
+        {
+        }
+
+        protected ExplorerException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/explorer.api/Explorers/ExplorerImpl.cs
+++ b/src/explorer.api/Explorers/ExplorerImpl.cs
@@ -6,13 +6,13 @@ namespace Explorer
     using Aircloak.JsonApi;
     using Aircloak.JsonApi.ResponseTypes;
 
-    internal abstract class ExplorerImpl
+    internal abstract class ExplorerBase
     {
         private readonly ConcurrentBag<IExploreMetric> metrics;
 
         private readonly IQueryResolver queryResolver;
 
-        protected ExplorerImpl(IQueryResolver queryResolver)
+        protected ExplorerBase(IQueryResolver queryResolver)
         {
             this.queryResolver = queryResolver;
 

--- a/src/explorer.api/Explorers/ExplorerImpl.cs
+++ b/src/explorer.api/Explorers/ExplorerImpl.cs
@@ -8,7 +8,7 @@ namespace Explorer
 
     internal abstract class ExplorerImpl
     {
-        private readonly ConcurrentBag<ExploreResult.Metric> metrics;
+        private readonly ConcurrentBag<IExploreMetric> metrics;
 
         private readonly IQueryResolver queryResolver;
 
@@ -16,17 +16,17 @@ namespace Explorer
         {
             this.queryResolver = queryResolver;
 
-            metrics = new ConcurrentBag<ExploreResult.Metric>();
+            metrics = new ConcurrentBag<IExploreMetric>();
         }
 
-        public ExploreResult.Metric[] Metrics
+        public IExploreMetric[] Metrics
         {
             get => metrics.ToArray();
         }
 
         public abstract Task Explore();
 
-        protected void PublishMetric(ExploreResult.Metric metric)
+        protected void PublishMetric(IExploreMetric metric)
         {
             metrics.Add(metric);
         }

--- a/src/explorer.api/Explorers/ExplorerImpl.cs
+++ b/src/explorer.api/Explorers/ExplorerImpl.cs
@@ -1,0 +1,41 @@
+namespace Explorer
+{
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+
+    using Aircloak.JsonApi;
+    using Aircloak.JsonApi.ResponseTypes;
+
+    internal abstract class ExplorerImpl
+    {
+        private readonly ConcurrentBag<ExploreResult.Metric> metrics;
+
+        private readonly IQueryResolver queryResolver;
+
+        protected ExplorerImpl(IQueryResolver queryResolver)
+        {
+            this.queryResolver = queryResolver;
+
+            metrics = new ConcurrentBag<ExploreResult.Metric>();
+        }
+
+        public ExploreResult.Metric[] Metrics
+        {
+            get => metrics.ToArray();
+        }
+
+        public abstract Task Explore();
+
+        protected void PublishMetric(ExploreResult.Metric metric)
+        {
+            metrics.Add(metric);
+        }
+
+        protected async Task<QueryResult<TResult>> ResolveQuery<TResult>(
+            IQuerySpec<TResult> query,
+            System.TimeSpan timeout)
+        {
+            return await queryResolver.ResolveQuery(query, timeout);
+        }
+    }
+}

--- a/src/explorer.api/Explorers/IExploreMetric.cs
+++ b/src/explorer.api/Explorers/IExploreMetric.cs
@@ -1,0 +1,9 @@
+namespace Explorer
+{
+    internal interface IExploreMetric
+    {
+        public string Name { get; }
+
+        public object Metric { get; set; }
+    }
+}

--- a/src/explorer.api/Explorers/IQueryResolver.cs
+++ b/src/explorer.api/Explorers/IQueryResolver.cs
@@ -1,0 +1,14 @@
+namespace Explorer
+{
+    using System.Threading.Tasks;
+
+    using Aircloak.JsonApi;
+    using Aircloak.JsonApi.ResponseTypes;
+
+    internal interface IQueryResolver
+    {
+        public Task<QueryResult<TResult>> ResolveQuery<TResult>(
+            IQuerySpec<TResult> query,
+            System.TimeSpan timeout);
+    }
+}

--- a/src/explorer.api/Explorers/IntegerColumnExplorer.cs
+++ b/src/explorer.api/Explorers/IntegerColumnExplorer.cs
@@ -36,10 +36,6 @@
                 new DistinctColumnValues(ExploreParams.TableName, ExploreParams.ColumnName),
                 timeout: TimeSpan.FromMinutes(2));
 
-            // Start the min-max explorer
-            var minMaxExplorer = new MinMaxExplorer(ApiClient, ExploreParams);
-            var minMaxTask = Task.Run(minMaxExplorer.Explore);
-
             var suppressedValueCount = distinctValueQ.ResultRows.Sum(row =>
                     row.ColumnValue.IsSuppressed ? row.Count : 0);
 

--- a/src/explorer.api/Explorers/IntegerColumnExplorer.cs
+++ b/src/explorer.api/Explorers/IntegerColumnExplorer.cs
@@ -4,10 +4,9 @@
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi.ResponseTypes;
     using Explorer.Queries;
 
-    internal class IntegerColumnExplorer : ExplorerImpl
+    internal class IntegerColumnExplorer : ExplorerBase
     {
         // TODO: The following should be configuration items (?)
         private const long ValuesPerBucketTarget = 20;

--- a/src/explorer.api/Explorers/IntegerColumnExplorer.cs
+++ b/src/explorer.api/Explorers/IntegerColumnExplorer.cs
@@ -21,9 +21,9 @@
             ColumnName = columnName;
         }
 
-        public string TableName { get; set; }
+        private string TableName { get; }
 
-        public string ColumnName { get; set; }
+        private string ColumnName { get; }
 
         public override async Task Explore()
         {

--- a/src/explorer.api/Explorers/IntegerColumnExplorer.cs
+++ b/src/explorer.api/Explorers/IntegerColumnExplorer.cs
@@ -1,7 +1,6 @@
 ﻿namespace Explorer
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
 
@@ -10,7 +9,7 @@
     using Explorer.Api.Models;
     using Explorer.Queries;
 
-    internal class IntegerColumnExplorer : ColumnExplorer
+    internal class IntegerColumnExplorer : ExplorerImpl
     {
         // TODO: The following should be configuration items (?)
         private const long ValuesPerBucketTarget = 20;
@@ -20,20 +19,18 @@
         public IntegerColumnExplorer(JsonApiClient apiClient, ExploreParams exploreParams)
             : base(apiClient, exploreParams)
         {
-            ExploreMetrics = Array.Empty<ExploreResult.Metric>();
         }
-
-        public IEnumerable<ExploreResult.Metric> ExploreMetrics { get; set; }
 
         public override async Task Explore()
         {
-            LatestResult = new ExploreResult(ExplorationGuid, status: Status.New);
-
             var stats = (await ResolveQuery<NumericColumnStats.IntegerResult>(
                 new NumericColumnStats(ExploreParams.TableName, ExploreParams.ColumnName),
                 timeout: TimeSpan.FromMinutes(2)))
                 .ResultRows
                 .Single();
+
+            PublishMetric(new ExploreResult.Metric(name: "naive_min", value: stats.Min));
+            PublishMetric(new ExploreResult.Metric(name: "naive_max", value: stats.Max));
 
             var distinctValueQ = await ResolveQuery<DistinctColumnValues.IntegerResult>(
                 new DistinctColumnValues(ExploreParams.TableName, ExploreParams.ColumnName),
@@ -50,10 +47,8 @@
 
             if (totalValueCount == 0)
             {
-                LatestResult = new ExploreError(
-                    ExplorationGuid,
-                    $"Cannot explore table/column: Invalid value count.");
-                return;
+                throw new Exception(
+                    $"Total value count for {ExploreParams.TableName}, {ExploreParams.ColumnName} is zero.");
             }
 
             var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
@@ -71,14 +66,8 @@
                         row.Count,
                     };
 
-                ExploreMetrics = ExploreMetrics
-                    .Append(new ExploreResult.Metric(name: "distinct_values", value: distinctValues))
-                    .Append(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
-
-                LatestResult = new ExploreResult(
-                    ExplorationGuid,
-                    status: Status.Complete,
-                    metrics: ExploreMetrics);
+                PublishMetric(new ExploreResult.Metric(name: "distinct_values", value: distinctValues));
+                PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
 
                 return;
             }
@@ -122,6 +111,8 @@
                     row.Count,
                 };
 
+            PublishMetric(new ExploreResult.Metric(name: "histogram_buckets", value: histogramBuckets));
+
             // Estimate Median
             var processed = 0;
             var target = (double)totalValueCount / 2;
@@ -141,29 +132,14 @@
                 }
             }
 
+            PublishMetric(new ExploreResult.Metric(name: "median_estimate", value: (long)medianEstimate));
+
             // Estimate Average
             var averageEstimate = histogramBuckets
                 .Sum(bucket => bucket.Count * (bucket.LowerBound + (bucket.BucketSize / 2)))
                 / totalValueCount;
 
-            ExploreMetrics = ExploreMetrics
-                    .Append(new ExploreResult.Metric(name: "histogram_buckets", value: histogramBuckets))
-                    .Append(new ExploreResult.Metric(name: "median_estimate", value: (long)medianEstimate))
-                    .Append(new ExploreResult.Metric(name: "avg_estimate", value: decimal.Round(averageEstimate, 2)))
-                    .Append(new ExploreResult.Metric(name: "naive_min", value: stats.Min))
-                    .Append(new ExploreResult.Metric(name: "naive_max", value: stats.Max));
-
-            LatestResult = new ExploreResult(ExplorationGuid, status: Status.Processing, metrics: ExploreMetrics);
-
-            await minMaxTask;
-            if (minMaxExplorer.LatestResult.Status == Status.Complete)
-            {
-                ExploreMetrics = ExploreMetrics
-                    .Concat(minMaxExplorer.LatestResult.Metrics);
-            }
-
-            LatestResult = new ExploreResult(ExplorationGuid, status: Status.Complete, metrics: ExploreMetrics);
-            return;
+            PublishMetric(new ExploreResult.Metric(name: "avg_estimate", value: decimal.Round(averageEstimate, 2)));
         }
     }
 }

--- a/src/explorer.api/Explorers/IntegerColumnExplorer.cs
+++ b/src/explorer.api/Explorers/IntegerColumnExplorer.cs
@@ -33,8 +33,8 @@
                 .ResultRows
                 .Single();
 
-            PublishMetric(new ExploreResult.Metric(name: "naive_min", value: stats.Min));
-            PublishMetric(new ExploreResult.Metric(name: "naive_max", value: stats.Max));
+            PublishMetric(new UntypedMetric(name: "naive_min", metric: stats.Min));
+            PublishMetric(new UntypedMetric(name: "naive_max", metric: stats.Max));
 
             var distinctValueQ = await ResolveQuery<DistinctColumnValues.IntegerResult>(
                 new DistinctColumnValues(TableName, ColumnName),
@@ -66,8 +66,8 @@
                         row.Count,
                     };
 
-                PublishMetric(new ExploreResult.Metric(name: "distinct_values", value: distinctValues));
-                PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
+                PublishMetric(new UntypedMetric(name: "distinct_values", metric: distinctValues));
+                PublishMetric(new UntypedMetric(name: "suppressed_values", metric: suppressedValueCount));
 
                 return;
             }
@@ -111,7 +111,7 @@
                     row.Count,
                 };
 
-            PublishMetric(new ExploreResult.Metric(name: "histogram_buckets", value: histogramBuckets));
+            PublishMetric(new UntypedMetric(name: "histogram_buckets", metric: histogramBuckets));
 
             // Estimate Median
             var processed = 0;
@@ -132,14 +132,14 @@
                 }
             }
 
-            PublishMetric(new ExploreResult.Metric(name: "median_estimate", value: (long)medianEstimate));
+            PublishMetric(new UntypedMetric(name: "median_estimate", metric: (long)medianEstimate));
 
             // Estimate Average
             var averageEstimate = histogramBuckets
                 .Sum(bucket => bucket.Count * (bucket.LowerBound + (bucket.BucketSize / 2)))
                 / totalValueCount;
 
-            PublishMetric(new ExploreResult.Metric(name: "avg_estimate", value: decimal.Round(averageEstimate, 2)));
+            PublishMetric(new UntypedMetric(name: "avg_estimate", metric: decimal.Round(averageEstimate, 2)));
         }
     }
 }

--- a/src/explorer.api/Explorers/MinMaxExplorer.cs
+++ b/src/explorer.api/Explorers/MinMaxExplorer.cs
@@ -7,7 +7,7 @@ namespace Explorer
 
     using Explorer.Queries;
 
-    internal class MinMaxExplorer : ExplorerImpl
+    internal class MinMaxExplorer : ExplorerBase
     {
         public MinMaxExplorer(IQueryResolver queryResolver, string tableName, string columnName)
             : base(queryResolver)

--- a/src/explorer.api/Explorers/MinMaxExplorer.cs
+++ b/src/explorer.api/Explorers/MinMaxExplorer.cs
@@ -1,23 +1,26 @@
 namespace Explorer
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi;
-    using Explorer.Api.Models;
     using Explorer.Queries;
 
     internal class MinMaxExplorer : ExplorerImpl
     {
-        public MinMaxExplorer(JsonApiClient apiClient, ExploreParams exploreParams)
-            : base(apiClient, exploreParams)
+        public MinMaxExplorer(IQueryResolver queryResolver, string tableName, string columnName)
+            : base(queryResolver)
         {
+            TableName = tableName;
+            ColumnName = columnName;
         }
 
         private delegate Task<decimal?> Estimator(decimal? bound = null);
+
+        public string TableName { get; set; }
+
+        public string ColumnName { get; set; }
 
         public override async Task Explore()
         {
@@ -49,7 +52,7 @@ namespace Explorer
 
         private async Task<decimal?> GetMinEstimate(decimal? upperBound = null) =>
             (await ResolveQuery<Min.Result>(
-                new Min(ExploreParams.TableName, ExploreParams.ColumnName, upperBound),
+                new Min(TableName, ColumnName, upperBound),
                 timeout: TimeSpan.FromMinutes(2)))
                 .ResultRows
                 .Single()
@@ -57,7 +60,7 @@ namespace Explorer
 
         private async Task<decimal?> GetMaxEstimate(decimal? lowerBound = null) =>
             (await ResolveQuery<Max.Result>(
-                new Max(ExploreParams.TableName, ExploreParams.ColumnName, lowerBound),
+                new Max(TableName, ColumnName, lowerBound),
                 timeout: TimeSpan.FromMinutes(2)))
                 .ResultRows
                 .Single()

--- a/src/explorer.api/Explorers/MinMaxExplorer.cs
+++ b/src/explorer.api/Explorers/MinMaxExplorer.cs
@@ -18,9 +18,9 @@ namespace Explorer
 
         private delegate Task<decimal?> Estimator(decimal? bound = null);
 
-        public string TableName { get; set; }
+        private string TableName { get; }
 
-        public string ColumnName { get; set; }
+        private string ColumnName { get; }
 
         public override async Task Explore()
         {

--- a/src/explorer.api/Explorers/MinMaxExplorer.cs
+++ b/src/explorer.api/Explorers/MinMaxExplorer.cs
@@ -47,7 +47,7 @@ namespace Explorer
 
             Debug.Assert(result.HasValue, $"Unexpected null result when refining {(isMin ? "Min" : "Max")} estimate.");
 
-            PublishMetric(new ExploreResult.Metric(name: isMin ? "refined_min" : "refined_max", value: result.Value));
+            PublishMetric(new UntypedMetric(name: isMin ? "refined_min" : "refined_max", metric: result.Value));
         }
 
         private async Task<decimal?> GetMinEstimate(decimal? upperBound = null) =>

--- a/src/explorer.api/Explorers/RealColumnExplorer.cs
+++ b/src/explorer.api/Explorers/RealColumnExplorer.cs
@@ -21,9 +21,9 @@
             ColumnName = columnName;
         }
 
-        public string TableName { get; set; }
+        private string TableName { get; }
 
-        public string ColumnName { get; set; }
+        private string ColumnName { get; }
 
         public override async Task Explore()
         {

--- a/src/explorer.api/Explorers/RealColumnExplorer.cs
+++ b/src/explorer.api/Explorers/RealColumnExplorer.cs
@@ -4,10 +4,9 @@
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi.ResponseTypes;
     using Explorer.Queries;
 
-    internal class RealColumnExplorer : ExplorerImpl
+    internal class RealColumnExplorer : ExplorerBase
     {
         // TODO: The following should be configuration items (?)
         private const long ValuesPerBucketTarget = 20;

--- a/src/explorer.api/Explorers/RealColumnExplorer.cs
+++ b/src/explorer.api/Explorers/RealColumnExplorer.cs
@@ -33,8 +33,8 @@
                 .ResultRows
                 .Single();
 
-            PublishMetric(new ExploreResult.Metric(name: "naive_min", value: stats.Min));
-            PublishMetric(new ExploreResult.Metric(name: "naive_max", value: stats.Max));
+            PublishMetric(new UntypedMetric(name: "naive_min", metric: stats.Min));
+            PublishMetric(new UntypedMetric(name: "naive_max", metric: stats.Max));
 
             var distinctValueQ = await ResolveQuery<DistinctColumnValues.RealResult>(
                 new DistinctColumnValues(TableName, ColumnName),
@@ -66,8 +66,8 @@
                         row.Count,
                     };
 
-                PublishMetric(new ExploreResult.Metric(name: "distinct_values", value: distinctValues));
-                PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
+                PublishMetric(new UntypedMetric(name: "distinct_values", metric: distinctValues));
+                PublishMetric(new UntypedMetric(name: "suppressed_values", metric: suppressedValueCount));
 
                 return;
             }
@@ -111,7 +111,7 @@
                     row.Count,
                 };
 
-            PublishMetric(new ExploreResult.Metric(name: "histogram_buckets", value: histogramBuckets));
+            PublishMetric(new UntypedMetric(name: "histogram_buckets", metric: histogramBuckets));
 
             // Estimate Median
             var processed = 0;
@@ -132,14 +132,14 @@
                 }
             }
 
-            PublishMetric(new ExploreResult.Metric(name: "median_estimate", value: medianEstimate));
+            PublishMetric(new UntypedMetric(name: "median_estimate", metric: medianEstimate));
 
             // Estimate Average
             var averageEstimate = histogramBuckets
                 .Sum(bucket => bucket.Count * (bucket.LowerBound + (bucket.BucketSize / 2)))
                 / totalValueCount;
 
-            PublishMetric(new ExploreResult.Metric(name: "avg_estimate", value: decimal.Round(averageEstimate, 2)));
+            PublishMetric(new UntypedMetric(name: "avg_estimate", metric: decimal.Round(averageEstimate, 2)));
         }
     }
 }

--- a/src/explorer.api/Explorers/RealColumnExplorer.cs
+++ b/src/explorer.api/Explorers/RealColumnExplorer.cs
@@ -37,10 +37,6 @@
                 new DistinctColumnValues(ExploreParams.TableName, ExploreParams.ColumnName),
                 timeout: TimeSpan.FromMinutes(2));
 
-            // Start the min-max explorer
-            var minMaxExplorer = new MinMaxExplorer(ApiClient, ExploreParams);
-            var minMaxTask = Task.Run(minMaxExplorer.Explore);
-
             var suppressedValueCount = distinctValueQ.ResultRows.Sum(row =>
                     row.ColumnValue.IsSuppressed ? row.Count : 0);
 

--- a/src/explorer.api/Explorers/TextColumnExplorer.cs
+++ b/src/explorer.api/Explorers/TextColumnExplorer.cs
@@ -29,7 +29,7 @@ namespace Explorer
             var suppressedValueCount = distinctValues.ResultRows.Sum(row =>
                     row.ColumnValue.IsSuppressed ? row.Count : 0);
 
-            PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
+            PublishMetric(new UntypedMetric(name: "suppressed_values", metric: suppressedValueCount));
 
             var totalValueCount = distinctValues.ResultRows.Sum(row => row.Count);
 
@@ -40,7 +40,7 @@ namespace Explorer
                     $"Total value count for {TableName}, {ColumnName} is zero.");
             }
 
-            PublishMetric(new ExploreResult.Metric(name: "total_count", value: totalValueCount));
+            PublishMetric(new UntypedMetric(name: "total_count", metric: totalValueCount));
 
             var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
 
@@ -54,7 +54,7 @@ namespace Explorer
                     row.Count,
                 };
 
-            PublishMetric(new ExploreResult.Metric(name: "top_distinct_values", value: distinctValueCounts.Take(10)));
+            PublishMetric(new UntypedMetric(name: "top_distinct_values", metric: distinctValueCounts.Take(10)));
         }
     }
 }

--- a/src/explorer.api/Explorers/TextColumnExplorer.cs
+++ b/src/explorer.api/Explorers/TextColumnExplorer.cs
@@ -4,10 +4,9 @@ namespace Explorer
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Aircloak.JsonApi.ResponseTypes;
     using Explorer.Queries;
 
-    internal class TextColumnExplorer : ExplorerImpl
+    internal class TextColumnExplorer : ExplorerBase
     {
         public TextColumnExplorer(IQueryResolver queryResolver, string tableName, string columnName)
             : base(queryResolver)

--- a/src/explorer.api/Explorers/TextColumnExplorer.cs
+++ b/src/explorer.api/Explorers/TextColumnExplorer.cs
@@ -16,9 +16,9 @@ namespace Explorer
             ColumnName = columnName;
         }
 
-        public string TableName { get; set; }
+        private string TableName { get; }
 
-        public string ColumnName { get; set; }
+        private string ColumnName { get; }
 
         public override async Task Explore()
         {

--- a/src/explorer.api/Explorers/TextColumnExplorer.cs
+++ b/src/explorer.api/Explorers/TextColumnExplorer.cs
@@ -10,7 +10,7 @@ namespace Explorer
     using Explorer.Api.Models;
     using Explorer.Queries;
 
-    internal class TextColumnExplorer : ColumnExplorer
+    internal class TextColumnExplorer : ExplorerImpl
     {
         public TextColumnExplorer(JsonApiClient apiClient, ExploreParams exploreParams)
             : base(apiClient, exploreParams)
@@ -22,8 +22,6 @@ namespace Explorer
 
         public override async Task Explore()
         {
-            LatestResult = new ExploreResult(ExplorationGuid, status: Status.Processing);
-
             var distinctValues = await ResolveQuery<DistinctColumnValues.TextResult>(
                 new DistinctColumnValues(ExploreParams.TableName, ExploreParams.ColumnName),
                 timeout: TimeSpan.FromMinutes(2));
@@ -36,10 +34,8 @@ namespace Explorer
             // This shouldn't happen, but check anyway.
             if (totalValueCount == 0)
             {
-                LatestResult = new ExploreError(
-                    ExplorationGuid,
-                    $"Cannot explore table/column: value count is zero.");
-                return;
+                throw new Exception(
+                    $"Total value count for {ExploreParams.TableName}, {ExploreParams.ColumnName} is zero.");
             }
 
             var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
@@ -54,17 +50,9 @@ namespace Explorer
                     row.Count,
                 };
 
-            ExploreMetrics = ExploreMetrics
-                .Append(new ExploreResult.Metric(name: "top_distinct_values", value: distinctValueCounts.Take(10)))
-                .Append(new ExploreResult.Metric(name: "total_count", value: totalValueCount))
-                .Append(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
-
-            LatestResult = new ExploreResult(
-                ExplorationGuid,
-                status: Status.Complete,
-                metrics: ExploreMetrics);
-
-            return;
+            PublishMetric(new ExploreResult.Metric(name: "top_distinct_values", value: distinctValueCounts.Take(10)));
+            PublishMetric(new ExploreResult.Metric(name: "total_count", value: totalValueCount));
+            PublishMetric(new ExploreResult.Metric(name: "suppressed_values", value: suppressedValueCount));
         }
     }
 }

--- a/src/explorer.api/Explorers/UntypedMetric.cs
+++ b/src/explorer.api/Explorers/UntypedMetric.cs
@@ -1,0 +1,15 @@
+namespace Explorer
+{
+    internal struct UntypedMetric : IExploreMetric
+    {
+        public UntypedMetric(string name, object metric)
+        {
+            Name = name;
+            Metric = metric;
+        }
+
+        public string Name { get; }
+
+        public object Metric { get; set; }
+    }
+}

--- a/src/explorer.api/Models/ExploreError.cs
+++ b/src/explorer.api/Models/ExploreError.cs
@@ -3,7 +3,7 @@ namespace Explorer.Api.Models
     internal class ExploreError : ExploreResult
     {
         public ExploreError(System.Guid explorationId, string description)
-            : base(explorationId, "error")
+            : base(explorationId, ExploreStatus.Error)
         {
             Description = description;
         }

--- a/src/explorer.api/Models/ExploreResult.cs
+++ b/src/explorer.api/Models/ExploreResult.cs
@@ -26,7 +26,17 @@ namespace Explorer
 
         public Guid Id { get; }
 
-        internal class Metric
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public enum ExploreStatus
+        {
+            New,
+            Processing,
+            Complete,
+            Error,
+
+        }
+
+        public class Metric
         {
             public Metric(string name, object value)
             {
@@ -39,16 +49,6 @@ namespace Explorer
 
             [JsonPropertyName("value")]
             public object MetricValue { get; set; }
-        }
-
-        [JsonConverter(typeof(JsonStringEnumConverter))]
-        public enum ExploreStatus
-        {
-            New,
-            Processing,
-            Complete,
-            Error,
-
         }
     }
 }

--- a/src/explorer.api/Models/ExploreResult.cs
+++ b/src/explorer.api/Models/ExploreResult.cs
@@ -6,21 +6,21 @@ namespace Explorer
 
     internal class ExploreResult
     {
-        public ExploreResult(Guid explorationId, string status)
+        public ExploreResult(Guid explorationId, ExploreStatus status)
         {
             Id = explorationId;
             Status = status;
             Metrics = Array.Empty<Metric>();
         }
 
-        public ExploreResult(Guid explorationId, string status, IEnumerable<Metric> metrics)
+        public ExploreResult(Guid explorationId, ExploreStatus status, IEnumerable<Metric> metrics)
         {
             Id = explorationId;
             Status = status;
             Metrics = metrics;
         }
 
-        public string Status { get; }
+        public ExploreStatus Status { get; }
 
         public IEnumerable<Metric> Metrics { get; }
 
@@ -39,6 +39,16 @@ namespace Explorer
 
             [JsonPropertyName("value")]
             public object MetricValue { get; set; }
+        }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public enum ExploreStatus
+        {
+            New,
+            Processing,
+            Complete,
+            Error,
+
         }
     }
 }

--- a/src/explorer.api/Queries/DistinctColumnValues.cs
+++ b/src/explorer.api/Queries/DistinctColumnValues.cs
@@ -25,9 +25,9 @@ namespace Explorer.Queries
                         from {TableName}
                         group by {ColumnName}";
 
-        public string TableName { get; }
+        private string TableName { get; }
 
-        public string ColumnName { get; }
+        private string ColumnName { get; }
 
         IntegerResult IQuerySpec<IntegerResult>.FromJsonArray(ref Utf8JsonReader reader)
         {

--- a/src/explorer.api/Queries/Max.cs
+++ b/src/explorer.api/Queries/Max.cs
@@ -3,7 +3,6 @@ namespace Explorer.Queries
     using System.Text.Json;
 
     using Aircloak.JsonApi;
-    using Explorer.Api.Models;
 
     internal class Max :
         IQuerySpec<Max.Result>
@@ -33,11 +32,11 @@ namespace Explorer.Queries
             }
         }
 
-        public string TableName { get; }
+        private string TableName { get; }
 
-        public string ColumnName { get; }
+        private string ColumnName { get; }
 
-        public decimal? LowerBound { get; }
+        private decimal? LowerBound { get; }
 
         public Result FromJsonArray(ref Utf8JsonReader reader)
         {

--- a/src/explorer.api/Queries/Min.cs
+++ b/src/explorer.api/Queries/Min.cs
@@ -3,7 +3,6 @@ namespace Explorer.Queries
     using System.Text.Json;
 
     using Aircloak.JsonApi;
-    using Explorer.Api.Models;
 
     internal class Min :
         IQuerySpec<Min.Result>
@@ -33,11 +32,11 @@ namespace Explorer.Queries
             }
         }
 
-        public string TableName { get; }
+        private string TableName { get; }
 
-        public string ColumnName { get; }
+        private string ColumnName { get; }
 
-        public decimal? UpperBound { get; }
+        private decimal? UpperBound { get; }
 
         public Result FromJsonArray(ref Utf8JsonReader reader)
         {

--- a/src/explorer.api/Queries/NumericColumnStats.cs
+++ b/src/explorer.api/Queries/NumericColumnStats.cs
@@ -3,7 +3,6 @@ namespace Explorer.Queries
     using System.Text.Json;
 
     using Aircloak.JsonApi;
-    using Explorer.Api.Models;
 
     internal class NumericColumnStats :
         IQuerySpec<NumericColumnStats.IntegerResult>,
@@ -23,9 +22,9 @@ namespace Explorer.Queries
                             count_noise(*)
                         from {TableName}";
 
-        public string TableName { get; }
+        private string TableName { get; }
 
-        public string ColumnName { get; }
+        private string ColumnName { get; }
 
         IntegerResult IQuerySpec<IntegerResult>.FromJsonArray(ref Utf8JsonReader reader)
         {

--- a/src/explorer.api/Queries/SingleColumnHistogram.cs
+++ b/src/explorer.api/Queries/SingleColumnHistogram.cs
@@ -46,11 +46,11 @@ namespace Explorer.Queries
             }
         }
 
-        public string TableName { get; }
+        private string TableName { get; }
 
-        public string ColumnName { get; }
+        private string ColumnName { get; }
 
-        public IList<decimal> Buckets { get; }
+        private IList<decimal> Buckets { get; }
 
         public Result FromJsonArray(ref Utf8JsonReader reader)
         {

--- a/tests/explorer.api.tests/QueryTests.cs
+++ b/tests/explorer.api.tests/QueryTests.cs
@@ -111,9 +111,9 @@ namespace Explorer.Api.Tests
 
             const decimal expectedMin = 3288M;
             const decimal expectedMax = 495725M;
-            var actualMin = (decimal)metrics.Single(m => m.MetricName == "refined_min").MetricValue;
+            var actualMin = (decimal)metrics.Single(m => m.Name == "refined_min").Metric;
             Assert.True(actualMin == expectedMin, $"Expected {expectedMin}, got {actualMin}");
-            var actualMax = (decimal)metrics.Single(m => m.MetricName == "refined_max").MetricValue;
+            var actualMax = (decimal)metrics.Single(m => m.Name == "refined_max").Metric;
             Assert.True(actualMax == expectedMax, $"Expected {expectedMax}, got {actualMax}");
         }
 
@@ -166,13 +166,13 @@ namespace Explorer.Api.Tests
         }
 
         private void CheckDistinctCategories(
-            IEnumerable<ExploreResult.Metric> distinctMetrics,
+            IEnumerable<IExploreMetric> distinctMetrics,
             IEnumerable<dynamic> expectedValues)
         {
             var distinctValues =
                 (IEnumerable<dynamic>)distinctMetrics
-                .Single(m => m.MetricName == "top_distinct_values")
-                .MetricValue;
+                .Single(m => m.Name == "top_distinct_values")
+                .Metric;
 
             Assert.All<(dynamic, dynamic)>(distinctValues.Zip(expectedValues), tuple =>
             {
@@ -184,14 +184,14 @@ namespace Explorer.Api.Tests
 
             var expectedTotal = expectedValues.Sum(v => (long)v.Count);
             var actualTotal = (long)distinctMetrics
-                .Single(m => m.MetricName == "total_count")
-                .MetricValue;
+                .Single(m => m.Name == "total_count")
+                .Metric;
             Assert.True(expectedTotal == actualTotal, $"Expected total of {expectedTotal}, got {actualTotal}");
 
             const long expectedSuppressed = 0L;
             var actualSuppressed = (long)distinctMetrics
-                .Single(m => m.MetricName == "suppressed_values")
-                .MetricValue;
+                .Single(m => m.Name == "suppressed_values")
+                .Metric;
             Assert.True(
                 actualSuppressed == expectedSuppressed,
                 $"Expected total of {expectedSuppressed}, got {actualSuppressed}");
@@ -210,7 +210,7 @@ namespace Explorer.Api.Tests
                 factory.GetApiPollingFrequencty(vcrCassetteInfo));
         }
 
-        private async Task<IEnumerable<ExploreResult.Metric>> GetExplorerMetrics(
+        private async Task<IEnumerable<IExploreMetric>> GetExplorerMetrics(
             string dataSourceName,
             Func<IQueryResolver, ExplorerImpl> implFactory,
             [CallerMemberName] string vcrSessionName = "")

--- a/tests/explorer.api.tests/QueryTests.cs
+++ b/tests/explorer.api.tests/QueryTests.cs
@@ -220,10 +220,9 @@ namespace Explorer.Api.Tests
             var jsonApiClient = new JsonApiClient(client);
 
             var queryResolver = new AircloakQueryResolver(jsonApiClient, dataSourceName);
-            var explorer = new ColumnExplorer();
-            explorer.Spawn(implFactory(queryResolver));
+            var explorer = new ColumnExplorer(new[] { implFactory(queryResolver), });
 
-            await explorer.Completion();
+            await explorer.Completion;
 
             return explorer.ExploreMetrics;
         }

--- a/tests/explorer.api.tests/QueryTests.cs
+++ b/tests/explorer.api.tests/QueryTests.cs
@@ -212,7 +212,7 @@ namespace Explorer.Api.Tests
 
         private async Task<IEnumerable<IExploreMetric>> GetExplorerMetrics(
             string dataSourceName,
-            Func<IQueryResolver, ExplorerImpl> implFactory,
+            Func<IQueryResolver, ExplorerBase> explorerFactory,
             [CallerMemberName] string vcrSessionName = "")
         {
             var vcrCassetteInfo = factory.GetVcrCasetteInfo(nameof(QueryTests), vcrSessionName);
@@ -220,7 +220,7 @@ namespace Explorer.Api.Tests
             var jsonApiClient = new JsonApiClient(client);
 
             var queryResolver = new AircloakQueryResolver(jsonApiClient, dataSourceName);
-            var explorer = new ColumnExplorer(new[] { implFactory(queryResolver), });
+            var explorer = new Exploration(new[] { explorerFactory(queryResolver), });
 
             await explorer.Completion;
 


### PR DESCRIPTION
This resolves #48 and further refactors the ColumnExplorer, better separating the Explorer concerns from the Api. 

Improvements:
- An explorer now consists of a collection of `ExplorerImpl`s which simply publish metrics.
- The `ColumnExplorer` keeps track of the ExplorerImpls and collates and provides access to metrics.
- Extracted query resolution to a separate interface `IQueryResolver`. This will help separate concerns between the explorer implementations, the aircloak api, the explorer api models... 
- An explorer now consists of a collection of `ExplorerImpl`s which simply publish metrics.
- The Explorer is no longer responsible for managing an external `Status`. Instead, this can be derived from the status of the running `Task` object.
- Totally decoupled from the `ExploreResult` definition - this is a concern of the api, not the explorer functionality. 
- Defined an `IExploreMetric` interface to avoid using `ExploreResult.Metric` all over the place. 