### PR TITLE
Daniel/simplify distinct query

### DIFF
--- a/src/aircloak/JsonApi/JsonConversion/JsonReaderExtensions.cs
+++ b/src/aircloak/JsonApi/JsonConversion/JsonReaderExtensions.cs
@@ -227,7 +227,11 @@ namespace Aircloak.JsonApi.JsonReaderExtensions
             (ref Utf8JsonReader reader) => reader.GetDateTime();
 
         private static readonly Utf8JsonValueParser<JsonElement> RawJsonElementParser =
-            (ref Utf8JsonReader reader) => JsonDocument.ParseValue(ref reader).RootElement;
+            (ref Utf8JsonReader reader) =>
+            {
+                using var jdoc = JsonDocument.ParseValue(ref reader);
+                return jdoc.RootElement.Clone();
+            };
 
         private static readonly Dictionary<System.Type, object> DefaultParsers = new Dictionary<System.Type, object>
         {

--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -155,11 +155,11 @@ namespace Explorer.Api.Controllers
                 },
                 AircloakType.Text => new ExplorerBase[]
                 {
-                    new TextColumnExplorer(resolver, data.TableName, data.ColumnName),
+                    new CategoricalColumnExplorer(resolver, data.TableName, data.ColumnName),
                 },
                 AircloakType.Bool => new ExplorerBase[]
                 {
-                    new BoolColumnExplorer(resolver, data.TableName, data.ColumnName),
+                    new CategoricalColumnExplorer(resolver, data.TableName, data.ColumnName),
                 },
                 AircloakType.Datetime => new ExplorerBase[]
                 {

--- a/src/explorer.api/Explorers/BoolColumnExplorer.cs
+++ b/src/explorer.api/Explorers/BoolColumnExplorer.cs
@@ -5,6 +5,7 @@ namespace Explorer
     using System.Threading;
     using System.Threading.Tasks;
 
+    using Explorer.Diffix.Extensions;
     using Explorer.Queries;
 
     internal class BoolColumnExplorer : ExplorerBase
@@ -22,16 +23,13 @@ namespace Explorer
 
         public override async Task Explore(CancellationToken cancellationToken)
         {
-            var distinctValues = await ResolveQuery<DistinctColumnValues.Result<bool>>(
+            var distinctValuesQ = await ResolveQuery<DistinctColumnValues.Result>(
                 new DistinctColumnValues(TableName, ColumnName),
                 cancellationToken);
 
-            var suppressedValueCount = distinctValues.ResultRows.Sum(row =>
-                    row.DistinctData.IsSuppressed ? row.Count : 0);
+            var (totalValueCount, suppressedValueCount) = distinctValuesQ.ResultRows.CountTotalAndSuppressed();
 
             PublishMetric(new UntypedMetric(name: "suppressed_values", metric: suppressedValueCount));
-
-            var totalValueCount = distinctValues.ResultRows.Sum(row => row.Count);
 
             // This shouldn't happen, but check anyway.
             if (totalValueCount == 0)
@@ -45,7 +43,7 @@ namespace Explorer
             var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
 
             var distinctValueCounts =
-                from row in distinctValues.ResultRows
+                from row in distinctValuesQ.ResultRows
                 where !row.DistinctData.IsSuppressed
                 orderby row.Count descending
                 select new

--- a/src/explorer.api/Explorers/CategoricalColumnExplorer.cs
+++ b/src/explorer.api/Explorers/CategoricalColumnExplorer.cs
@@ -1,0 +1,58 @@
+namespace Explorer
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Explorer.Diffix.Extensions;
+    using Explorer.Queries;
+
+    internal class CategoricalColumnExplorer : ExplorerBase
+    {
+        public CategoricalColumnExplorer(IQueryResolver queryResolver, string tableName, string columnName)
+            : base(queryResolver)
+        {
+            TableName = tableName;
+            ColumnName = columnName;
+        }
+
+        private string TableName { get; }
+
+        private string ColumnName { get; }
+
+        public override async Task Explore(CancellationToken cancellationToken)
+        {
+            var distinctValuesQ = await ResolveQuery<DistinctColumnValues.Result>(
+                new DistinctColumnValues(TableName, ColumnName),
+                cancellationToken);
+
+            var (totalValueCount, suppressedValueCount) = distinctValuesQ.ResultRows.CountTotalAndSuppressed();
+
+            PublishMetric(new UntypedMetric(name: "suppressed_values", metric: suppressedValueCount));
+
+            // This shouldn't happen, but check anyway.
+            if (totalValueCount == 0)
+            {
+                throw new Exception(
+                    $"Total value count for {TableName}, {ColumnName} is zero.");
+            }
+
+            PublishMetric(new UntypedMetric(name: "total_count", metric: totalValueCount));
+
+            var suppressedValueRatio = (double)suppressedValueCount / totalValueCount;
+
+            var distinctValueCounts =
+                from row in distinctValuesQ.ResultRows
+                where !row.DistinctData.IsSuppressed
+                orderby row.Count descending
+                select new
+                {
+                    row.DistinctData.Value,
+                    row.Count,
+                };
+
+            PublishMetric(new UntypedMetric(name: "top_distinct_values", metric: distinctValueCounts.Take(10)));
+        }
+    }
+}

--- a/src/explorer.api/Explorers/DatetimeColumnExplorer.cs
+++ b/src/explorer.api/Explorers/DatetimeColumnExplorer.cs
@@ -30,16 +30,16 @@
 
         public override async Task Explore(CancellationToken cancellationToken)
         {
-            var statsQ = (await ResolveQuery<NumericColumnStats.Result<DateTime>>(
+            var statsQ = await ResolveQuery<NumericColumnStats.Result<DateTime>>(
                 new NumericColumnStats(TableName, ColumnName),
-                cancellationToken));
+                cancellationToken);
 
             var stats = statsQ.ResultRows.Single();
 
             PublishMetric(new UntypedMetric(name: "naive_min", metric: stats.Min));
             PublishMetric(new UntypedMetric(name: "naive_max", metric: stats.Max));
 
-            var distinctValueQ = await ResolveQuery<DistinctColumnValues.Result<DateTime>>(
+            var distinctValueQ = await ResolveQuery<DistinctColumnValues.Result>(
                 new DistinctColumnValues(TableName, ColumnName),
                 cancellationToken);
 

--- a/src/explorer.api/Explorers/IntegerColumnExplorer.cs
+++ b/src/explorer.api/Explorers/IntegerColumnExplorer.cs
@@ -36,7 +36,7 @@ namespace Explorer
             PublishMetric(new UntypedMetric(name: "naive_min", metric: stats.Min));
             PublishMetric(new UntypedMetric(name: "naive_max", metric: stats.Max));
 
-            var distinctValueQ = await ResolveQuery<DistinctColumnValues.Result<long>>(
+            var distinctValueQ = await ResolveQuery<DistinctColumnValues.Result>(
                 new DistinctColumnValues(TableName, ColumnName),
                 cancellationToken);
 

--- a/src/explorer.api/Explorers/RealColumnExplorer.cs
+++ b/src/explorer.api/Explorers/RealColumnExplorer.cs
@@ -36,7 +36,7 @@ namespace Explorer
             PublishMetric(new UntypedMetric(name: "naive_min", metric: stats.Min));
             PublishMetric(new UntypedMetric(name: "naive_max", metric: stats.Max));
 
-            var distinctValueQ = await ResolveQuery<DistinctColumnValues.Result<double>>(
+            var distinctValueQ = await ResolveQuery<DistinctColumnValues.Result>(
                 new DistinctColumnValues(TableName, ColumnName),
                 cancellationToken);
 

--- a/src/explorer.api/Extensions/DiffixExtensions.cs
+++ b/src/explorer.api/Extensions/DiffixExtensions.cs
@@ -7,7 +7,7 @@ namespace Explorer.Diffix.Extensions
 
     internal static class DiffixExtensions
     {
-        public static (long, long) CountTotalAndSuppressed<T>(this IEnumerable<T> valueCounts)
+        public static (long Total, long Suppressed) CountTotalAndSuppressed<T>(this IEnumerable<T> valueCounts)
         where T : ICountAggregate, INullable, ISuppressible
         => valueCounts.Aggregate(
                 (0L, 0L),

--- a/tests/explorer.api.tests/QueryTests.cs
+++ b/tests/explorer.api.tests/QueryTests.cs
@@ -37,7 +37,8 @@ namespace Explorer.Api.Tests
             Assert.All(intResult.ResultRows, row =>
             {
                 Assert.True(row.DistinctData.IsNull || row.DistinctData.IsSuppressed ||
-                    row.DistinctData.Value.ValueKind == JsonValueKind.Number);
+                    (row.DistinctData.Value.ValueKind == JsonValueKind.Number &&
+                    row.DistinctData.Value.GetInt32() >= 0));
                 Assert.True(row.Count > 0);
                 Assert.True(row.CountNoise.HasValue);
             });
@@ -56,7 +57,8 @@ namespace Explorer.Api.Tests
             Assert.All(realResult.ResultRows, row =>
             {
                 Assert.True(row.DistinctData.IsNull || row.DistinctData.IsSuppressed ||
-                    row.DistinctData.Value.ValueKind == JsonValueKind.Number);
+                    (row.DistinctData.Value.ValueKind == JsonValueKind.Number &&
+                    row.DistinctData.Value.GetDouble() >= 0));
                 Assert.True(row.Count > 0);
             });
         }
@@ -74,6 +76,8 @@ namespace Explorer.Api.Tests
             Assert.All(textResult.ResultRows, row =>
             {
                 Assert.True(row.DistinctData.Value.ValueKind == JsonValueKind.String);
+                Assert.True(row.DistinctData.Value.GetString() == "Male" ||
+                            row.DistinctData.Value.GetString() == "Female");
                 Assert.True(row.Count > 0);
                 Assert.True(row.CountNoise.HasValue);
             });


### PR DESCRIPTION
I simplified the distinct values query - we are usually not interested in the data type of the column. All we care about is how many different values there are / whether they suppressed or null. 

This allows to remove the type parameters from the query result, and to create a generic explorer for categorical columns such as text / bool. 

Helps with issue #53 