### PR TITLE
bug fix for min/max explorer

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,20 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "test",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "test",
+                "explorer.sln"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "build explorer.api",
             "command": "dotnet",
             "type": "shell",

--- a/src/explorer.api/Explorers/MinMaxExplorer.cs
+++ b/src/explorer.api/Explorers/MinMaxExplorer.cs
@@ -10,6 +10,8 @@ namespace Explorer
 
     internal class MinMaxExplorer : ExplorerBase
     {
+        private const int MaxIterations = 10;
+
         public MinMaxExplorer(IQueryResolver queryResolver, string tableName, string columnName)
             : base(queryResolver)
         {
@@ -40,10 +42,16 @@ namespace Explorer
 
             estimate = await estimator(result, cancellationToken);
 
-            while (estimate.HasValue && estimate != result)
+            for (var i = 0; i < MaxIterations; i++)
             {
                 result = estimate;
                 estimate = await estimator(result, cancellationToken);
+                if ((!estimate.HasValue) ||
+                    (isMin ? estimate >= result : estimate <= result) ||
+                    (isMin && estimate == decimal.Zero))
+                {
+                    break;
+                }
             }
 
             Debug.Assert(result.HasValue, $"Unexpected null result when refining {(isMin ? "Min" : "Max")} estimate.");


### PR DESCRIPTION
In some cases the explorer could get into loop where the min or max
value don't converge.

To prevent this from happening, instead of checking for
`estimate == result`, check for `>=` or `<=` depending on whether
 it's a max or min.

Also, the number of iterations has been limited to
10 (this should be more than enough).