### PR TITLE
Explorer Components

### DIFF
--- a/src/explorer/Common/ExplorerBase.cs
+++ b/src/explorer/Common/ExplorerBase.cs
@@ -5,16 +5,69 @@ namespace Explorer.Common
     using System.Threading.Tasks;
 
     using Diffix;
+    using Explorer.Explorers.Components;
+    using Explorer.Explorers.Metrics;
 
-    internal abstract class ExplorerBase
+    internal abstract class ExplorerBase : MetricsPublisher
     {
+        private readonly List<Task> componentTasks = new List<Task>();
+
         private readonly ConcurrentBag<ExploreMetric> metrics = new ConcurrentBag<ExploreMetric>();
+
+        protected ExplorerBase() { }
+
+        protected ExplorerBase(DConnection conn, ExplorerContext ctx)
+        {
+            Conn = conn;
+            Ctx = ctx;
+        }
+
+        public DConnection Conn { get; }
+
+        public ExplorerContext Ctx { get; }
 
         public IEnumerable<ExploreMetric> Metrics => metrics.ToArray();
 
-        public abstract Task Explore(DConnection conn, ExplorerContext ctx);
+        public async Task Explore()
+        {
+            InitializeComponents();
+            await Task.WhenAll(componentTasks);
+        }
+
+        public virtual Task Explore(DConnection conn, ExplorerContext ctx)
+        {
+            return Explore();
+        }
+
+        protected virtual void InitializeComponents() { }
 
         public virtual void PublishMetric(ExploreMetric metric) =>
             metrics.Add(metric);
+
+        protected async Task RunAndPublish<T>(ExplorerComponent<T> component)
+        {
+            var result = await component.ResultAsync;
+            if (result is MetricsProvider provider && this is MetricsPublisher publisher)
+            {
+                await publisher.PublishMetricsAsync(provider);
+            }
+        }
+
+        protected TComponent Initialize<TComponent, TResult>()
+            where TComponent : ExplorerComponent<TResult>
+        {
+            var instance = typeof(TComponent)
+                .GetConstructor(new[] { typeof(DConnection), typeof(ExplorerContext) })
+                ?.Invoke(new object[] { Conn, Ctx })
+                ?? throw new System.Exception("Expected an instance of ExplorerComponent with a constructor");
+
+            if (instance is TComponent component)
+            {
+                componentTasks.Add(RunAndPublish(component));
+                return component;
+            }
+
+            throw new System.Exception("Unable to create an instance of ExplorerComponent.");
+        }
     }
 }

--- a/src/explorer/Exploration.cs
+++ b/src/explorer/Exploration.cs
@@ -3,7 +3,6 @@ namespace Explorer
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
 
     using Diffix;
@@ -50,8 +49,9 @@ namespace Explorer
             {
                 DValueType.Integer => new (ExplorerBase, ExplorerContext)[]
                 {
-                    (new IntegerColumnExplorer(), ctx),
-                    (new MinMaxExplorer(), ctx),
+                    (new NumericColumnExplorer(conn, ctx), ctx),
+                    // (new IntegerColumnExplorer(), ctx),
+                    // (new MinMaxExplorer(), ctx),
                 },
                 DValueType.Real => new (ExplorerBase, ExplorerContext)[]
                 {

--- a/src/explorer/Explorers/Components/AverageEstimator.cs
+++ b/src/explorer/Explorers/Components/AverageEstimator.cs
@@ -1,0 +1,56 @@
+namespace Explorer.Explorers.Components
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Explorers.Metrics;
+
+    internal class AverageEstimator : ExplorerComponent<AverageEstimator.Result>, DependsOn<NumericHistogramComponent.Result>
+    {
+        private ExplorerComponent<NumericHistogramComponent.Result>? histogramComponent;
+
+        public AverageEstimator(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        public void LinkToSourceComponent(ExplorerComponent<NumericHistogramComponent.Result> component)
+        {
+            histogramComponent = component;
+        }
+
+        protected override async Task<Result> Explore()
+        {
+            histogramComponent ??= new NumericHistogramComponent(Conn, Ctx);
+
+            var histogram = await histogramComponent.ResultAsync;
+
+            var averageEstimate = await Task.Run(() =>
+            {
+                var sum = histogram.Buckets
+                        .Where(b => b.HasValue)
+                        .Sum(bucket => bucket.Count * ((decimal)bucket.LowerBound.Value + (histogram.BucketSize / 2)));
+                return sum / histogram.ValueCounts.NonSuppressedNonNullCount;
+            });
+
+            return new Result(averageEstimate);
+        }
+
+        public class Result : MetricsProvider
+        {
+            public Result(decimal value)
+            {
+                Value = value;
+            }
+
+            public decimal Value { get; }
+
+            public IEnumerable<ExploreMetric> Metrics()
+            {
+                yield return new UntypedMetric(name: "average_estimate", metric: decimal.Round(Value, 4));
+            }
+        }
+    }
+}

--- a/src/explorer/Explorers/Components/DependsOn.cs
+++ b/src/explorer/Explorers/Components/DependsOn.cs
@@ -1,0 +1,7 @@
+namespace Explorer.Explorers.Components
+{
+    internal interface DependsOn<TResult>
+    {
+        public void LinkToSourceComponent(ExplorerComponent<TResult> component);
+    }
+}

--- a/src/explorer/Explorers/Components/DistinctValuesComponent.cs
+++ b/src/explorer/Explorers/Components/DistinctValuesComponent.cs
@@ -1,0 +1,77 @@
+namespace Explorer.Explorers.Components
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Queries;
+
+    internal class DistinctValuesComponent
+        : ExplorerComponent<DistinctValuesComponent.Result>
+    {
+        public DistinctValuesComponent(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        protected override async Task<Result> Explore()
+        {
+            var distinctValueQ = await Conn.Exec(
+                new DistinctColumnValues(Ctx.Table, Ctx.Column));
+
+            var counts = ValueCounts.Compute(distinctValueQ.Rows);
+
+            if (counts.TotalCount == 0)
+            {
+                throw new Exception(
+                    $"Total value count for {Ctx.Table}, {Ctx.Column} is zero.");
+            }
+
+            return new Result(distinctValueQ.Rows, counts);
+        }
+
+        public class Result : Metrics.MetricsProvider
+        {
+            private const double SuppressedRatioThreshold = 0.1;
+
+            public Result(
+                IEnumerable<ValueWithCount<JsonElement>> distinctRows,
+                ValueCounts valueCounts)
+            {
+                DistinctRows = distinctRows;
+                ValueCounts = valueCounts;
+            }
+
+            public IEnumerable<ValueWithCount<JsonElement>> DistinctRows { get; }
+
+            public ValueCounts ValueCounts { get; }
+
+            public IEnumerable<ExploreMetric> Metrics()
+            {
+                if (ValueCounts.SuppressedRowRatio < SuppressedRatioThreshold)
+                {
+                    // Only few of the values are suppressed. This means the data is already well-segmented and can be
+                    // considered categorical or quasi-categorical.
+                    var distinctValues =
+                        from row in DistinctRows
+                        where row.HasValue
+                        orderby row.Count descending
+                        select new
+                        {
+                            row.Value,
+                            row.Count,
+                        };
+
+                    yield return new UntypedMetric(name: "distinct.values", metric: distinctValues);
+                    yield return new UntypedMetric(name: "distinct.null_count", metric: ValueCounts.NullCount);
+                    yield return new UntypedMetric(name: "distinct.suppressed_count", metric: ValueCounts.SuppressedCount);
+                    yield return new UntypedMetric(name: "distinct.value_count", metric: ValueCounts.TotalCount);
+                }
+            }
+        }
+    }
+}

--- a/src/explorer/Explorers/Components/ExplorerComponent.cs
+++ b/src/explorer/Explorers/Components/ExplorerComponent.cs
@@ -1,0 +1,35 @@
+namespace Explorer.Explorers.Components
+{
+    using System.Threading.Tasks;
+
+    using Diffix;
+    using Explorer.Common;
+
+    internal abstract class ExplorerComponent<TResult>
+    {
+        private Task<TResult>? componentTask;
+
+        protected ExplorerComponent(DConnection conn, ExplorerContext ctx)
+        {
+            Conn = conn;
+            Ctx = ctx;
+        }
+
+        public DConnection Conn { get; }
+
+        public ExplorerContext Ctx { get; }
+
+        public Task<TResult> ResultAsync
+        {
+            get => componentTask ??= Task.Run(async () => await Explore());
+        }
+
+        public ExplorerComponent<TResult> LinkToDependentComponent(DependsOn<TResult> component)
+        {
+            component.LinkToSourceComponent(this);
+            return this;
+        }
+
+        protected abstract Task<TResult> Explore();
+    }
+}

--- a/src/explorer/Explorers/Components/MinMaxRefiner.cs
+++ b/src/explorer/Explorers/Components/MinMaxRefiner.cs
@@ -1,0 +1,117 @@
+namespace Explorer.Explorers.Components
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Queries;
+
+    internal class MinMaxRefiner : ExplorerComponent<MinMaxRefiner.Result>
+    {
+        private const int MaxIterations = 10;
+
+        public MinMaxRefiner(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        protected override async Task<Result> Explore()
+        {
+            return new Result(await RefinedMinEstimate(), await RefinedMaxEstimate());
+        }
+
+        private async Task<decimal> RefinedMinEstimate()
+        {
+            // initial unconstrained min or max
+            var result = await GetMinEstimate(null);
+
+            // limit the number of iterations
+            for (var i = 0; i < MaxIterations; i++)
+            {
+                // If we have a zero result, it can't be improved upon anyway.
+                if (result == decimal.Zero)
+                {
+                    break;
+                }
+
+                // Constrained query to get an improved estimate
+                var estimate = await GetMinEstimate(result);
+
+                // If there are no longer enough values in the constrained range to compute an anonymised min/max,
+                // the query will return `null` => we can't improve further on the result.
+                // Same thing if the results start to diverge (second part of if condition).
+                if ((!estimate.HasValue) || (estimate >= result))
+                {
+                    break;
+                }
+                result = estimate;
+            }
+
+            Debug.Assert(result.HasValue, "Unexpected null result when refining Min estimate.");
+
+            return result.Value;
+        }
+
+        private async Task<decimal> RefinedMaxEstimate()
+        {
+            // initial unconstrained min or max
+            var result = await GetMaxEstimate(null);
+
+            // limit the number of iterations
+            for (var i = 0; i < MaxIterations; i++)
+            {
+                // Constrained query to get an improved estimate
+                var estimate = await GetMaxEstimate(result);
+
+                // If there are no longer enough values in the constrained range to compute an anonymised min/max,
+                // the query will return `null` => we can't improve further on the result.
+                // Same thing if the results start to diverge (second part of if condition).
+                if ((!estimate.HasValue) || (estimate <= result))
+                {
+                    break;
+                }
+                result = estimate;
+            }
+
+            Debug.Assert(result.HasValue, "Unexpected null result when refining Max estimate.");
+
+            return result.Value;
+        }
+
+        private async Task<decimal?> GetMinEstimate(decimal? upperBound)
+        {
+            var minQ = await Conn.Exec<Min.Result<decimal>>(
+                new Min(Ctx.Table, Ctx.Column, upperBound));
+            return minQ.Rows.Single().Min;
+        }
+
+        private async Task<decimal?> GetMaxEstimate(decimal? lowerBound)
+        {
+            var maxQ = await Conn.Exec<Max.Result<decimal>>(
+                new Max(Ctx.Table, Ctx.Column, lowerBound));
+            return maxQ.Rows.Single().Max;
+        }
+
+        public class Result : Metrics.MetricsProvider
+        {
+            public Result(decimal min, decimal max)
+            {
+                Max = max;
+                Min = min;
+            }
+
+            public decimal Min { get; }
+
+            public decimal Max { get; }
+
+            public IEnumerable<ExploreMetric> Metrics()
+            {
+                yield return new UntypedMetric("refined_min", Min);
+                yield return new UntypedMetric("refined_max", Max);
+            }
+        }
+    }
+}

--- a/src/explorer/Explorers/Components/NumericHistogramComponent.cs
+++ b/src/explorer/Explorers/Components/NumericHistogramComponent.cs
@@ -1,0 +1,94 @@
+namespace Explorer.Explorers.Components
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Explorers.Metrics;
+    using Explorer.Queries;
+
+    internal class NumericHistogramComponent :
+        ExplorerComponent<NumericHistogramComponent.Result>,
+        DependsOn<SimpleStats<double>.Result>
+    {
+        private const long ValuesPerBucketTarget = 20;
+
+        private ExplorerComponent<SimpleStats<double>.Result>? statsComponent;
+
+        public NumericHistogramComponent(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        public void LinkToSourceComponent(ExplorerComponent<SimpleStats<double>.Result> component)
+        {
+            statsComponent = component;
+        }
+
+        protected async override Task<Result> Explore()
+        {
+            statsComponent ??= new SimpleStats<double>(Conn, Ctx);
+
+            var stats = await statsComponent.ResultAsync;
+
+            var bucketsToSample = BucketUtils.EstimateBucketResolutions(
+                stats.Count, stats.Min, stats.Max, ValuesPerBucketTarget);
+
+            var histogramQ = await Conn.Exec(new SingleColumnHistogram(Ctx.Table, Ctx.Column, bucketsToSample));
+
+            var histograms = histogramQ.Rows
+                .GroupBy(
+                    row => row.GroupingLabel,
+                    (bucketSize, buckets) => new Result(
+                        bucketSize,
+                        ValueCounts.Compute(buckets),
+                        buckets.Where(b => b.LowerBound.HasValue).OrderBy(b => b.LowerBound.Value)));
+
+            return histograms
+                .OrderBy(h => h.BucketSize)
+                .ThenBy(h => h.ValueCounts.SuppressedCount)
+                .First();
+        }
+
+        public class Result : MetricsProvider
+        {
+            public Result(
+                decimal bucketSize,
+                ValueCounts valueCounts,
+                IEnumerable<SingleColumnHistogram.Result> buckets)
+            {
+                BucketSize = bucketSize;
+                ValueCounts = valueCounts;
+                Buckets = buckets;
+            }
+
+            public decimal BucketSize { get; set; }
+
+            public ValueCounts ValueCounts { get; set; }
+
+            public IEnumerable<SingleColumnHistogram.Result> Buckets { get; set; }
+
+            public IEnumerable<ExploreMetric> Metrics()
+            {
+                var buckets = Buckets
+                    .Where(b => b.HasValue)
+                    .Select(b => new
+                    {
+                        BucketSize,
+                        LowerBound = b.GroupingValue,
+                        b.Count,
+                    });
+
+                return new List<ExploreMetric>
+                {
+                    new UntypedMetric("histogram.buckets", buckets),
+                    new UntypedMetric("histogram.suppressed_count", ValueCounts.SuppressedCount),
+                    new UntypedMetric("histogram.suppressed_ratio", ValueCounts.SuppressedCountRatio),
+                    new UntypedMetric("histogram.value_counts", ValueCounts),
+                };
+            }
+        }
+    }
+}

--- a/src/explorer/Explorers/Components/QuartileEstimator.cs
+++ b/src/explorer/Explorers/Components/QuartileEstimator.cs
@@ -1,0 +1,111 @@
+namespace Explorer.Explorers.Components
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Explorers.Metrics;
+
+    internal class QuartileEstimator :
+        ExplorerComponent<QuartileEstimator.Result>,
+        DependsOn<NumericHistogramComponent.Result>
+    {
+        private ExplorerComponent<NumericHistogramComponent.Result>? histogramComponent;
+
+        public QuartileEstimator(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        public void LinkToSourceComponent(ExplorerComponent<NumericHistogramComponent.Result> component)
+        {
+            histogramComponent = component;
+        }
+
+        protected override async Task<Result> Explore()
+        {
+            histogramComponent ??= new NumericHistogramComponent(Conn, Ctx);
+
+            var selectedHistogram = await histogramComponent.ResultAsync;
+
+            var quartileEstimates = new List<double>();
+            var quartileCount = selectedHistogram.ValueCounts.NonSuppressedNonNullCount / 4;
+            var quartile = 1;
+            var processed = 0L;
+
+            foreach (var bucket in selectedHistogram.Buckets.Where(b => b.HasValue))
+            {
+                if (processed + bucket.Count < quartileCount * quartile)
+                {
+                    // no quartiles in this bucket
+                    processed += bucket.Count;
+                }
+                else
+                {
+                    // one or more quartiles in this bucket
+                    var remaining = bucket.Count;
+                    var lowerBound = bucket.LowerBound.Value;
+                    var range = (double)selectedHistogram.BucketSize;
+
+                    do
+                    {
+                        var toProcess = (quartileCount * quartile) - processed;
+
+                        if (toProcess > remaining)
+                        {
+                            processed += remaining;
+                            break;
+                        }
+
+                        var subRange = (double)toProcess / remaining * range;
+                        var quartileEstimate = lowerBound + subRange;
+
+                        quartileEstimates.Add(quartileEstimate);
+
+                        lowerBound = quartileEstimate;
+                        range -= subRange;
+                        processed += toProcess;
+                        remaining -= toProcess;
+                        quartile++;
+                    }
+                    while (remaining > 0 && quartile <= 3);
+
+                    if (quartile > 3)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return new Result(quartileEstimates);
+        }
+
+        public class Result : MetricsProvider
+        {
+            public Result(List<double> quartiles)
+            {
+                if (quartiles.Count != 3)
+                {
+                    throw new System.Exception($"Expected three quartile values, got {quartiles.Count}.");
+                }
+
+                AsList = quartiles;
+                AsList.Sort();
+            }
+
+            public List<double> AsList { get; }
+
+            public double Q1 { get => AsList[0]; }
+
+            public double Q2 { get => AsList[1]; }
+
+            public double Q3 { get => AsList[2]; }
+
+            public IEnumerable<ExploreMetric> Metrics()
+            {
+                yield return new UntypedMetric(name: "quartile_estimates", metric: AsList);
+            }
+        }
+    }
+}

--- a/src/explorer/Explorers/Components/SimpleStats.cs
+++ b/src/explorer/Explorers/Components/SimpleStats.cs
@@ -1,0 +1,48 @@
+namespace Explorer.Explorers.Components
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Queries;
+
+    internal class SimpleStats<T> : ExplorerComponent<SimpleStats<T>.Result>
+    {
+        public SimpleStats(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        protected override async Task<SimpleStats<T>.Result> Explore()
+        {
+            var statsQ = await Conn.Exec(new BasicColumnStats<T>(Ctx.Table, Ctx.Column));
+
+            return new Result(statsQ.Rows.Single());
+        }
+
+        public class Result : Metrics.MetricsProvider
+        {
+            public Result(BasicColumnStats<T>.Result stats)
+            {
+                Stats = stats;
+            }
+
+            public BasicColumnStats<T>.Result Stats { get; }
+
+            public long Count { get => Stats.Count; }
+
+            public T Min { get => Stats.Min; }
+
+            public T Max { get => Stats.Max; }
+
+            public IEnumerable<ExploreMetric> Metrics()
+            {
+                yield return new UntypedMetric("count", Count);
+                yield return new UntypedMetric("naive_min", Min!);
+                yield return new UntypedMetric("naive_max", Max!);
+            }
+        }
+    }
+}

--- a/src/explorer/Explorers/Metrics/MetricsProvider.cs
+++ b/src/explorer/Explorers/Metrics/MetricsProvider.cs
@@ -1,0 +1,9 @@
+namespace Explorer.Explorers.Metrics
+{
+    using System.Collections.Generic;
+
+    public interface MetricsProvider
+    {
+        public IEnumerable<ExploreMetric> Metrics();
+    }
+}

--- a/src/explorer/Explorers/Metrics/MetricsPublisher.cs
+++ b/src/explorer/Explorers/Metrics/MetricsPublisher.cs
@@ -1,0 +1,23 @@
+namespace Explorer.Explorers.Metrics
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    internal interface MetricsPublisher
+    {
+        public void PublishMetric(ExploreMetric metric);
+
+        public void PublishMetrics(MetricsProvider provider)
+        {
+            foreach (var metric in provider.Metrics())
+            {
+                PublishMetric(metric);
+            }
+        }
+
+        public Task PublishMetricAsync(ExploreMetric metric) => Task.Run(() => PublishMetric(metric));
+
+        public Task PublishMetricsAsync(MetricsProvider provider) =>
+            Task.WhenAll(provider.Metrics().Select(PublishMetricAsync));
+    }
+}

--- a/src/explorer/Explorers/NumericColumnExplorer.cs
+++ b/src/explorer/Explorers/NumericColumnExplorer.cs
@@ -1,0 +1,28 @@
+namespace Explorer.Explorers
+{
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Explorers.Components;
+
+    internal class NumericColumnExplorer : ExplorerBase
+    {
+        public NumericColumnExplorer(DConnection conn, ExplorerContext ctx)
+        : base(conn, ctx)
+        {
+        }
+
+        protected override void InitializeComponents()
+        {
+            Initialize<SimpleStats<double>, SimpleStats<double>.Result>()
+                .LinkToDependentComponent((NumericHistogramComponent)
+                    Initialize<NumericHistogramComponent, NumericHistogramComponent.Result>()
+                    .LinkToDependentComponent(
+                        Initialize<QuartileEstimator, QuartileEstimator.Result>())
+                    .LinkToDependentComponent(
+                        Initialize<AverageEstimator, AverageEstimator.Result>()));
+
+            // Initialize<DistinctValuesComponent, DistinctValuesComponent.Result>();
+            Initialize<MinMaxRefiner, MinMaxRefiner.Result>();
+        }
+    }
+}

--- a/src/explorer/Queries/BasicColumnStats.cs
+++ b/src/explorer/Queries/BasicColumnStats.cs
@@ -1,0 +1,45 @@
+namespace Explorer.Queries
+{
+    using System.Text.Json;
+
+    using Diffix;
+    using Explorer.JsonExtensions;
+
+    internal class BasicColumnStats<T> :
+        DQuery<BasicColumnStats<T>.Result>
+    {
+        public BasicColumnStats(string tableName, string columnName)
+        {
+            QueryStatement = $@"
+                select
+                    min({columnName}),
+                    max({columnName}),
+                    count(*),
+                    count_noise(*)
+                from {tableName}";
+        }
+
+        public string QueryStatement { get; }
+
+        Result DQuery<Result>.ParseRow(ref Utf8JsonReader reader) => new Result(ref reader);
+
+        public class Result
+        {
+            public Result(ref Utf8JsonReader reader)
+            {
+                Min = reader.ParseNonNullableMetric<T>();
+                Max = reader.ParseNonNullableMetric<T>();
+                Count = reader.ParseCount();
+                CountNoise = reader.ParseCountNoise();
+            }
+
+            public T Min { get; set; }
+
+            public T Max { get; set; }
+
+            public long Count { get; set; }
+
+            public double? CountNoise { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
I refactored the explorer into components.
- ExplorerComponent is the base class for components.
- Components/ contains a bunch of defined components based on existing
explorers but broken down into smaller pieces.
- Metrics/ contains a couple of interfaces to help with publishing metrics.
- ExplorerBase has been changed to be usable with components.
- Integer column explorer has been replaced with a generic component based
explorer (NumericColumnExplorer) as an example.
- ExplorerComponents can implement `DependsOn` interface to enable linking
to other components that it depends on. (example: `QuartileEstimator` depends
on `NumericHistogramComponent`)

The implementation is compatible with the existing 'monollithic' `ExplorerBase` way of doing things, so we can break things up gradually into components. I think this will be useful going forward as we add more functionality with interlinked dependencies. 

@AndreiBozantan please let me know what you think . 