### PR TITLE
Add config for dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,52 @@
+version: 1
+update_configs:
+  - package_manager: "dotnet:nuget"
+    directory: "/src/aircloak/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"
+  - package_manager: "dotnet:nuget"
+    directory: "/src/diffix"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"
+  - package_manager: "dotnet:nuget"
+    directory: "/src/explorer"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"
+  - package_manager: "dotnet:nuget"
+    directory: "/src/explorer.api"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"
+  - package_manager: "dotnet:nuget"
+    directory: "/src/vcr-sharp"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "all"
+      - match:
+          dependency_type: "production"
+          update_type: "semver:patch"


### PR DESCRIPTION
Dependabot is immensely useful.
It looks through dependencies and ensure they are up to date.
That way we never end up with stale dependencies which become a nightmare to fix later.

To keep overhead low I have set it to auto-merge in the cases where tests pass and the update types seem safe. 
If you would rather we skip the auto-merge behavior, let me know.