### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/src/explorer.api/explorer.api.csproj
+++ b/src/explorer.api/explorer.api.csproj
@@ -10,10 +10,6 @@
     <ProjectReference Include="../aircloak/aircloak.csproj"/>
     <ProjectReference Include="../explorer/explorer.csproj"/>
   </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">


### PR DESCRIPTION
The dependency Microsoft.Extensions.Http is not needed in explorer.api as it is 
a transitive dependency already included in the aircloak project. 

This should also prevent conflicts arising when dependabot tries to bump versions
on both projects.