### PR TITLE
Daniel/add git info to docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,8 +31,8 @@
 	"remoteEnv": {
 		// [Optional] Override the default HTTP endpoints - need to listen to '*' for appPort to work
 		"ASPNETCORE_Kestrel__Endpoints__Http__Url": "http://*:5000",
-		// The api key should be defined in the local environment
-		"AIRCLOAK_API_KEY": "${localEnv:AIRCLOAK_API_KEY}"
+		// A development api key can be imported from the local environment
+		"Explorer__AircloakApiKey": "${localEnv:AIRCLOAK_API_KEY}"
 	},
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,4 +20,5 @@ jobs:
           registry: docker.pkg.github.com
           repository: diffix/explorer/explorer-api
           tag_with_ref: true
+          build_args: COMMIT_HASH={{ github.sha }},COMMIT_REF={{ github.ref }}
   

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,21 +16,6 @@
             }
         },
         {
-            "name": "explorer.api nightly",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/explorer.api/bin/Debug/netcoreapp3.1/explorer.api.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/src/explorer.api",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development",
-                "ASPNETCORE_URLS": "http://[::]:5000",
-                "AIRCLOAK_API_URL": "https://nightly-air.aircloak.com/api/"
-            }
-        },
-        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,13 @@ RUN dotnet publish $BUILD_TARGET -c release -o /app --no-restore > $BUILD_LOG
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+
+ARG COMMIT_HASH="Unknown"
+ARG COMMIT_REF="N/A"
+
+ENV Explorer__CommitHash=$COMMIT_HASH
+ENV Explorer__CommitRef=$COMMIT_REF
+
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["dotnet", "explorer.api.dll"]

--- a/src/aircloak/JsonApi/JsonApiClient.cs
+++ b/src/aircloak/JsonApi/JsonApiClient.cs
@@ -11,6 +11,7 @@ namespace Aircloak.JsonApi
     using Aircloak.JsonApi.JsonConversion;
     using Aircloak.JsonApi.ResponseTypes;
     using Diffix;
+    using Diffix.JsonConversion;
 
     /// <summary>
     /// Convenience class providing GET and POST methods adapted to the

--- a/src/diffix/JsonConversion/DValueTypeEnumConverter.cs
+++ b/src/diffix/JsonConversion/DValueTypeEnumConverter.cs
@@ -1,6 +1,6 @@
 #pragma warning disable CA1812 // DValueTypeEnumConverter is an internal class that is apparently never instantiated.
 
-namespace Aircloak.JsonApi.JsonConversion
+namespace Diffix.JsonConversion
 {
     using System;
     using System.Text.Json;
@@ -11,7 +11,7 @@ namespace Aircloak.JsonApi.JsonConversion
     /// <summary>
     /// <c>JsonConverter</c> for (de)serializing the <see cref="ValueType" /> enum as a string.
     /// </summary>
-    internal class DValueTypeEnumConverter : JsonConverter<DValueType>
+    public class DValueTypeEnumConverter : JsonConverter<DValueType>
     {
         private const string Integer = "integer";
         private const string Real = "real";

--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -20,13 +20,16 @@ namespace Explorer.Api.Controllers
     {
         private readonly ILogger<ExploreController> logger;
         private readonly ExplorationRegistry explorationRegistry;
+        private readonly VersionInfo versionInfo;
 
         public ExploreController(
             ILogger<ExploreController> logger,
-            ExplorationRegistry explorationRegistry)
+            ExplorationRegistry explorationRegistry,
+            VersionInfo versionInfo)
         {
             this.logger = logger;
             this.explorationRegistry = explorationRegistry;
+            this.versionInfo = versionInfo;
         }
 
         [HttpPost]
@@ -56,7 +59,7 @@ namespace Explorer.Api.Controllers
             // Register the exploration for future reference.
             var id = explorationRegistry.Register(exploration, cts);
 
-            return Ok(new ExploreResult(id, ExplorationStatus.New, data.DataSource, data.Table));
+            return Ok(new ExploreResult(id, ExplorationStatus.New, data.DataSource, data.Table, versionInfo));
         }
 
         [HttpGet]
@@ -93,7 +96,7 @@ namespace Explorer.Api.Controllers
                 }
             }
 
-            return Ok(new ExploreResult(explorationId, exploration));
+            return Ok(new ExploreResult(explorationId, exploration, versionInfo));
         }
 
         [HttpGet]

--- a/src/explorer.api/Exploration/ComponentComposition.cs
+++ b/src/explorer.api/Exploration/ComponentComposition.cs
@@ -7,8 +7,9 @@ namespace Explorer.Api
 
     public static class ComponentComposition
     {
-        public static Action<ExplorationConfig> ColumnConfiguration(DValueType columnType) =>
-            columnType switch
+        public static Action<ExplorationConfig> ColumnConfiguration(DValueType columnType)
+        {
+            Action<ExplorationConfig> typeBasedConfiguration = columnType switch
             {
                 DValueType.Integer => NumericExploration,
                 DValueType.Real => NumericExploration,
@@ -21,15 +22,26 @@ namespace Explorer.Api
                     $"Cannot explore column type {columnType}.", nameof(columnType)),
             };
 
-        private static void BoolExploration(ExplorationConfig config)
+            return config =>
+            {
+                CommonConfiguration(config);
+                typeBasedConfiguration(config);
+            };
+        }
+
+        private static void CommonConfiguration(ExplorationConfig config)
         {
             config.AddPublisher<ExplorationInfo>();
+            config.AddPublisher<ExplorerConfig>();
+        }
+
+        private static void BoolExploration(ExplorationConfig config)
+        {
             config.AddPublisher<DistinctValuesComponent>();
         }
 
         private static void NumericExploration(ExplorationConfig config)
         {
-            config.AddPublisher<ExplorationInfo>();
             config.AddPublisher<NumericHistogramComponent>();
             config.AddPublisher<QuartileEstimator>();
             config.AddPublisher<AverageEstimator>();
@@ -42,7 +54,6 @@ namespace Explorer.Api
 
         private static void TextExploration(ExplorationConfig config)
         {
-            config.AddPublisher<ExplorationInfo>();
             config.AddPublisher<DistinctValuesComponent>();
             config.AddPublisher<EmailCheckComponent>();
             config.AddPublisher<TextGeneratorComponent>();
@@ -51,7 +62,6 @@ namespace Explorer.Api
 
         private static void DatetimeExploration(ExplorationConfig config)
         {
-            config.AddPublisher<ExplorationInfo>();
             config.AddPublisher<DistinctValuesComponent>();
             config.AddPublisher<LinearTimeBuckets>();
             config.AddPublisher<CyclicalTimeBuckets>();

--- a/src/explorer.api/Exploration/ComponentComposition.cs
+++ b/src/explorer.api/Exploration/ComponentComposition.cs
@@ -32,7 +32,6 @@ namespace Explorer.Api
         private static void CommonConfiguration(ExplorationConfig config)
         {
             config.AddPublisher<ExplorationInfo>();
-            config.AddPublisher<ExplorerConfig>();
         }
 
         private static void BoolExploration(ExplorationConfig config)

--- a/src/explorer.api/ExplorerConfig.cs
+++ b/src/explorer.api/ExplorerConfig.cs
@@ -1,10 +1,14 @@
 namespace Explorer.Api
 {
-    using Aircloak.JsonApi;
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    public class ExplorerConfig : IAircloakAuthenticationProvider
+    using Aircloak.JsonApi;
+    using Explorer.Components;
+    using Explorer.Metrics;
+
+    public class ExplorerConfig : IAircloakAuthenticationProvider, PublisherComponent
     {
         public string AircloakApiKey { get; set; } = string.Empty;
 
@@ -17,5 +21,16 @@ namespace Explorer.Api
         public string CommitRef { get; set; } = string.Empty;
 
         public Task<string> GetAuthToken() => Task.FromResult(AircloakApiKey);
+
+        public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
+        {
+            yield return new UntypedMetric(
+                name: "version_info",
+                metric: new
+                {
+                    CommitHash,
+                    CommitRef,
+                });
+        }
     }
 }

--- a/src/explorer.api/ExplorerConfig.cs
+++ b/src/explorer.api/ExplorerConfig.cs
@@ -1,13 +1,21 @@
 namespace Explorer.Api
 {
+    using Aircloak.JsonApi;
     using System;
+    using System.Threading.Tasks;
 
-    public class ExplorerConfig
+    public class ExplorerConfig : IAircloakAuthenticationProvider
     {
-        public const string ApiKeyEnvironmentVariable = "AIRCLOAK_API_KEY";
+        public string AircloakApiKey { get; set; } = string.Empty;
 
         public uint PollFrequency { get; set; } = 2000;
 
         public TimeSpan PollFrequencyTimeSpan => TimeSpan.FromMilliseconds(PollFrequency);
+
+        public string CommitHash { get; set; } = string.Empty;
+
+        public string CommitRef { get; set; } = string.Empty;
+
+        public Task<string> GetAuthToken() => Task.FromResult(AircloakApiKey);
     }
 }

--- a/src/explorer.api/Models/ExploreResult.cs
+++ b/src/explorer.api/Models/ExploreResult.cs
@@ -9,7 +9,7 @@ namespace Explorer.Api.Models
 
     internal class ExploreResult
     {
-        public ExploreResult(Guid explorationId, ExplorationStatus status, string dataSource, string table)
+        public ExploreResult(Guid explorationId, ExplorationStatus status, string dataSource, string table, VersionInfo versionInfo)
         {
             Id = explorationId;
             Status = status;
@@ -17,9 +17,10 @@ namespace Explorer.Api.Models
             Table = table;
             Columns = Array.Empty<ColumnMetricsCollection>();
             SampleData = Array.Empty<IEnumerable<object?>>();
+            VersionInfo = versionInfo;
         }
 
-        public ExploreResult(Guid explorationId, Exploration exploration)
+        public ExploreResult(Guid explorationId, Exploration exploration, VersionInfo versionInfo)
         {
             Id = explorationId;
             Status = exploration.Status;
@@ -30,11 +31,14 @@ namespace Explorer.Api.Models
                 new ColumnMetricsCollection(
                     ce.Column,
                     ce.PublishedMetrics.Select(m => new Metric(m.Name, m.Metric))));
+            VersionInfo = versionInfo;
         }
 
         public Guid Id { get; }
 
         public ExplorationStatus Status { get; }
+
+        public VersionInfo VersionInfo { get; }
 
         public string DataSource { get; }
 

--- a/src/explorer.api/Models/VersionInfo.cs
+++ b/src/explorer.api/Models/VersionInfo.cs
@@ -1,0 +1,15 @@
+namespace Explorer.Api
+{
+    public class VersionInfo
+    {
+        public VersionInfo(ExplorerConfig config)
+        {
+            CommitHash = config.CommitHash;
+            CommitRef = config.CommitRef;
+        }
+
+        public string CommitHash { get; }
+
+        public string CommitRef { get; }
+    }
+}

--- a/src/explorer.api/Startup.cs
+++ b/src/explorer.api/Startup.cs
@@ -1,9 +1,7 @@
 namespace Explorer.Api
 {
     using Aircloak.JsonApi;
-    using Diffix;
     using Explorer.Api.Authentication;
-    using Explorer.Common;
     using Explorer.Components;
     using Explorer.Metrics;
     using Lamar;

--- a/src/explorer.api/appsettings.Development.json
+++ b/src/explorer.api/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "Explorer": {
-    "DefaultApiUrl": "https://attack.aircloak.com",
+    "DefaultApiUrl": "https://attack.aircloak.com/api/",
     "PollFrequency": 2020,
     "CommitHash": "n/a",
     "CommitRef": "development"

--- a/src/explorer.api/appsettings.Development.json
+++ b/src/explorer.api/appsettings.Development.json
@@ -1,7 +1,9 @@
 {
   "Explorer": {
-    "AircloakApiUrlDefault": "https://attack.aircloak.com/api/",
-    "PollFrequency": 2020
+    "DefaultApiUrl": "https://attack.aircloak.com",
+    "PollFrequency": 2020,
+    "CommitHash": "n/a",
+    "CommitRef": "development"
   },
   "Logging": {
     "LogLevel": {

--- a/src/explorer/Components/ExplorationInfo.cs
+++ b/src/explorer/Components/ExplorationInfo.cs
@@ -21,6 +21,7 @@ namespace Explorer.Components
                 ctx.DataSource,
                 ctx.Table,
                 ctx.Column,
+                ctx.ColumnType,
             });
         }
     }

--- a/src/explorer/Components/ExplorationInfo.cs
+++ b/src/explorer/Components/ExplorationInfo.cs
@@ -1,13 +1,11 @@
 namespace Explorer.Components
 {
     using System.Collections.Generic;
-    using System.Threading.Tasks;
 
     using Explorer.Common;
     using Explorer.Metrics;
 
-    public class ExplorationInfo
-        : ExplorerComponent<ExplorationInfo.Result>, PublisherComponent
+    public class ExplorationInfo : PublisherComponent
     {
         private readonly ExplorerContext ctx;
 
@@ -18,34 +16,12 @@ namespace Explorer.Components
 
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
         {
-            var r = await ResultAsync;
             yield return new UntypedMetric("exploration_info", new
             {
-                r.DataSource,
-                r.Table,
-                r.Column,
+                ctx.DataSource,
+                ctx.Table,
+                ctx.Column,
             });
-        }
-
-        protected override Task<Result> Explore()
-        {
-            return Task.FromResult(new Result(ctx.DataSource, ctx.Table, ctx.Column));
-        }
-
-        public class Result
-        {
-            public Result(string dataSource, string table, string column)
-            {
-                DataSource = dataSource;
-                Table = table;
-                Column = column;
-            }
-
-            public string DataSource { get; }
-
-            public string Table { get; }
-
-            public string Column { get; }
         }
     }
 }

--- a/src/explorer/Components/ExplorationInfo.cs
+++ b/src/explorer/Components/ExplorationInfo.cs
@@ -1,7 +1,10 @@
 namespace Explorer.Components
 {
     using System.Collections.Generic;
+    using System.Text.Json.Serialization;
 
+    using Diffix;
+    using Diffix.JsonConversion;
     using Explorer.Common;
     using Explorer.Metrics;
 
@@ -14,15 +17,18 @@ namespace Explorer.Components
             this.ctx = ctx;
         }
 
+        public string DataSource { get => ctx.DataSource; }
+
+        public string Table { get => ctx.Table; }
+
+        public string Column { get => ctx.Column; }
+
+        [JsonConverter(typeof(DValueTypeEnumConverter))]
+        public DValueType ColumnType { get => ctx.ColumnType; }
+
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
         {
-            yield return new UntypedMetric("exploration_info", new
-            {
-                ctx.DataSource,
-                ctx.Table,
-                ctx.Column,
-                ctx.ColumnType,
-            });
+            yield return new UntypedMetric("exploration_info", this);
         }
     }
 }

--- a/src/explorer/LamarExtensions.cs
+++ b/src/explorer/LamarExtensions.cs
@@ -11,9 +11,7 @@ namespace Explorer.Components
             // Try to resolve using the PublisherComponent interface. If this doesn't work, auto-resolve
             // the concrete instance instead.
             var fromCollection = (T)scope.TryGetInstance<PublisherComponent>(typeof(T).NameInCode());
-            return fromCollection is null
-                ? scope.GetInstance<T>()
-                : fromCollection;
+          return fromCollection ?? scope.GetInstance<T>();
         }
     }
 }

--- a/src/explorer/LamarExtensions.cs
+++ b/src/explorer/LamarExtensions.cs
@@ -7,6 +7,13 @@ namespace Explorer.Components
     {
         public static T ResolvePublisherComponent<T>(this INestedContainer scope)
             where T : PublisherComponent
-        => (T)scope.GetInstance<PublisherComponent>(typeof(T).NameInCode());
+        {
+            // Try to resolve using the PublisherComponent interface. If this doesn't work, auto-resolve
+            // the concrete instance instead.
+            var fromCollection = (T)scope.TryGetInstance<PublisherComponent>(typeof(T).NameInCode());
+            return fromCollection is null
+                ? scope.GetInstance<T>()
+                : fromCollection;
+        }
     }
 }

--- a/src/explorer/Metrics/UntypedMetric.cs
+++ b/src/explorer/Metrics/UntypedMetric.cs
@@ -2,7 +2,7 @@ namespace Explorer.Metrics
 {
     public struct UntypedMetric : ExploreMetric
     {
-        internal UntypedMetric(string name, object metric)
+        public UntypedMetric(string name, object metric)
         {
             Name = name;
             Metric = metric;

--- a/tests/appsettings.Test.json
+++ b/tests/appsettings.Test.json
@@ -1,0 +1,15 @@
+{
+    "Explorer": {
+        "DefaultApiUrl": "https://attack.aircloak.com/api/",
+        "PollFrequency": 2020,
+        "CommitHash": "n/a",
+        "CommitRef": "development"
+    },
+    "Logging": {
+        "LogLevel": {
+            "Default": "Info",
+            "Microsoft": "Info",
+            "Microsoft.Hosting.Lifetime": "Info"
+        }
+    }
+}

--- a/tests/appsettings.Test.json
+++ b/tests/appsettings.Test.json
@@ -7,9 +7,8 @@
     },
     "Logging": {
         "LogLevel": {
-            "Default": "Info",
-            "Microsoft": "Info",
-            "Microsoft.Hosting.Lifetime": "Info"
+            "Default": "Warning",
+            "Microsoft": "Warning"
         }
     }
 }

--- a/tests/explorer.api.tests/ExplorationTestFixture.cs
+++ b/tests/explorer.api.tests/ExplorationTestFixture.cs
@@ -7,12 +7,18 @@
     using Explorer.Components;
     using Explorer.Metrics;
     using Lamar;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using VcrSharp;
 
     public sealed class ExplorationTestFixture : IDisposable
     {
-        private const string ApiKeyEnvironmentVariable = "AIRCLOAK_API_KEY";
+        private static readonly ExplorerConfig Config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.Development.json")
+            .AddEnvironmentVariables()
+            .Build()
+            .GetSection("Explorer")
+            .Get<ExplorerConfig>();
 
         public ExplorationTestFixture()
         {
@@ -23,8 +29,7 @@
                 registry.Injectable<Cassette>();
 
                 // Configure Authentication
-                registry.For<IAircloakAuthenticationProvider>().Use(_ =>
-                    StaticApiKeyAuthProvider.FromEnvironmentVariable(ApiKeyEnvironmentVariable));
+                registry.For<IAircloakAuthenticationProvider>().Use(Config);
 
                 // Singleton services
                 registry.AddLogging();

--- a/tests/explorer.api.tests/ExplorationTestFixture.cs
+++ b/tests/explorer.api.tests/ExplorationTestFixture.cs
@@ -13,7 +13,7 @@
 
     public sealed class ExplorationTestFixture : IDisposable
     {
-        private static readonly ExplorerConfig Config = new ConfigurationBuilder()
+        public static ExplorerConfig Config { get; } = new ConfigurationBuilder()
             .AddJsonFile("appsettings.Development.json")
             .AddEnvironmentVariables()
             .Build()

--- a/tests/explorer.api.tests/TestWebAppFactory.cs
+++ b/tests/explorer.api.tests/TestWebAppFactory.cs
@@ -19,6 +19,7 @@
     {
         public static readonly ExplorerConfig Config = new ConfigurationBuilder()
             .AddJsonFile("appsettings.Development.json")
+            .AddEnvironmentVariables()
             .Build()
             .GetSection("Explorer")
             .Get<ExplorerConfig>();
@@ -32,8 +33,12 @@
 
         public static string GetAircloakApiKeyFromEnvironment()
         {
-            return Environment.GetEnvironmentVariable(ExplorerConfig.ApiKeyEnvironmentVariable) ??
-                throw new Exception($"Environment variable {ExplorerConfig.ApiKeyEnvironmentVariable} not set.");
+            if (string.IsNullOrEmpty(Config.AircloakApiKey))
+            {
+                throw new Exception("ApiKey needs to be set in environment or in config.");
+            }
+
+            return Config.AircloakApiKey;
         }
 
         public async Task<HttpResponseMessage> SendExplorerApiRequest(HttpMethod method, string endpoint, object? data, string testClassName, string vcrSessionName)

--- a/tests/explorer.api.tests/TestWebAppFactory.cs
+++ b/tests/explorer.api.tests/TestWebAppFactory.cs
@@ -11,6 +11,7 @@
     using Aircloak.JsonApi;
     using Explorer.Api;
     using Explorer.Api.Authentication;
+    using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc.Testing;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,7 @@
     public class TestWebAppFactory : WebApplicationFactory<Startup>
     {
         public static readonly ExplorerConfig Config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Test.json")
+            .AddJsonFile($"{Environment.CurrentDirectory}/../../../../appsettings.Test.json")
             .AddEnvironmentVariables()
             .Build()
             .GetSection("Explorer")
@@ -90,7 +91,7 @@
         }
 #pragma warning restore CA1822 // method should be made static
 
-        protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             var testConfig = GetTestConfig(GetType().Name, "WebHost.OutgoingRequests");
 

--- a/tests/explorer.api.tests/TestWebAppFactory.cs
+++ b/tests/explorer.api.tests/TestWebAppFactory.cs
@@ -18,7 +18,7 @@
     public class TestWebAppFactory : WebApplicationFactory<Startup>
     {
         public static readonly ExplorerConfig Config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Development.json")
+            .AddJsonFile("appsettings.Test.json")
             .AddEnvironmentVariables()
             .Build()
             .GetSection("Explorer")

--- a/tests/explorer.tests/QueryTests.cs
+++ b/tests/explorer.tests/QueryTests.cs
@@ -200,7 +200,7 @@
                 .PrepareTestScope()
                 .LoadCassette(ExplorerTestFixture.GenerateVcrFilename(this))
                 .OverrideVcrOptions(recordingOptions: VcrSharp.RecordingOptions.FailureOnly)
-                .WithConnectionParams(ExplorerTestFixture.ApiUrl, LongRunningQuery.DataSet);
+                .WithConnectionParams(testFixture.ApiUri, LongRunningQuery.DataSet);
 
             var queryTask = Task.Run(() => queryScope.QueryRows(new LongRunningQuery()));
 

--- a/tests/explorer.tests/Setup/ExplorerTestFixture.cs
+++ b/tests/explorer.tests/Setup/ExplorerTestFixture.cs
@@ -16,9 +16,10 @@ namespace Explorer.Tests
     public sealed class ExplorerTestFixture : IDisposable
     {
         private static readonly TestConfig Config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Development.json")
+            .AddJsonFile($"{Environment.CurrentDirectory}/../../../../appsettings.Test.json")
             .AddEnvironmentVariables()
             .Build()
+            .GetSection("Explorer")
             .Get<TestConfig>();
 
         public ExplorerTestFixture()

--- a/tests/explorer.tests/Setup/ExplorerTestFixture.cs
+++ b/tests/explorer.tests/Setup/ExplorerTestFixture.cs
@@ -4,18 +4,22 @@ namespace Explorer.Tests
     using System.Net.Http;
     using System.Runtime.CompilerServices;
     using System.Threading;
-
+    using System.Threading.Tasks;
     using Aircloak.JsonApi;
     using Diffix;
     using Explorer.Components;
     using Explorer.Metrics;
     using Lamar;
+    using Microsoft.Extensions.Configuration;
     using VcrSharp;
 
     public sealed class ExplorerTestFixture : IDisposable
     {
-        public static readonly Uri ApiUrl = new Uri("https://attack.aircloak.com/api/");
-        private const string ApiKeyEnvironmentVariable = "AIRCLOAK_API_KEY";
+        private static readonly TestConfig Config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.Development.json")
+            .AddEnvironmentVariables()
+            .Build()
+            .Get<TestConfig>();
 
         public ExplorerTestFixture()
         {
@@ -26,8 +30,7 @@ namespace Explorer.Tests
                 registry.Injectable<Cassette>();
 
                 // Configure Authentication
-                registry.For<IAircloakAuthenticationProvider>().Use(_ =>
-                    StaticApiKeyAuthProvider.FromEnvironmentVariable(ApiKeyEnvironmentVariable));
+                registry.For<IAircloakAuthenticationProvider>().Use(Config).Singleton();
 
                 // Cancellation
                 registry.Injectable<CancellationTokenSource>();
@@ -37,7 +40,11 @@ namespace Explorer.Tests
 
                 registry.IncludeRegistry<ComponentRegistry>();
             });
+
+            ApiUri = new Uri(Config.DefaultApiUrl);
         }
+
+        public Uri ApiUri { get; }
 
         public Container Container { get; }
 
@@ -51,7 +58,7 @@ namespace Explorer.Tests
             string vcrFilename) =>
             PrepareTestScope()
                 .LoadCassette(vcrFilename)
-                .WithConnectionParams(ApiUrl, dataSource);
+                .WithConnectionParams(ApiUri, dataSource);
 
 #pragma warning disable CA2000 // Call System.IDisposable.Dispose on object (Allow calling context to dispose the scope.)
         public ComponentTestScope SimpleComponentTestScope(
@@ -62,13 +69,22 @@ namespace Explorer.Tests
             DValueType columnType = DValueType.Unknown) =>
             PrepareTestScope()
                 .LoadCassette(vcrFilename)
-                .WithConnectionParams(ApiUrl, dataSource)
+                .WithConnectionParams(ApiUri, dataSource)
                 .WithContext(dataSource, table, column, columnType);
 #pragma warning restore CA2000 // Call System.IDisposable.Dispose on object
 
         public void Dispose()
         {
             Container.Dispose();
+        }
+
+        private class TestConfig : IAircloakAuthenticationProvider
+        {
+            public string AircloakApiKey { get; set; } = string.Empty;
+
+            public string DefaultApiUrl { get; set; } = string.Empty;
+
+            public Task<string> GetAuthToken() => Task.FromResult(AircloakApiKey);
         }
     }
 }


### PR DESCRIPTION
- Update the github release actions to Inject the github commit hash and ref (if any) to the published docker image. 
- Expose this information in the `ExplorerConfig` and publish as a metric.
- Reorganise configuration parsing, especially for testing. 
- Reduce logging output in test runs to make it easier to analyse logs (issue #165)

**Potential breaking change (dev environment only):** instead of `AIRCLOAK_API_KEY`, the app now looks for `Explorer__AircloakApiKey` in its environment. This is more consistent with Asp.Net conventions and allow automatic parsing and prioritisation of configuration variables via files / environment / command line args. If using vs code devcontainers, this should not be a problem, `AIRCLOAK_API_KEY` will be propagated and renamed from the local environment when building the development container. 