### PR TITLE
Fix format of numeric samples metric

### DIFF
--- a/src/explorer/Components/DistributionPublishers.cs/NumericSampleGenerator.cs
+++ b/src/explorer/Components/DistributionPublishers.cs/NumericSampleGenerator.cs
@@ -27,13 +27,11 @@ namespace Explorer.Components
         {
             yield return new UntypedMetric(
                 name: "sample_values",
-                metric: new
-                {
-                    Samples = distribution
+                metric: distribution
                         .Generate(SamplesToPublish)
                         .Select(s => ctx.ColumnType == Diffix.DValueType.Real ? s : Convert.ToInt64(s))
-                        .OrderBy(_ => _),
-                });
+                        .OrderBy(_ => _)
+                        .ToArray());
         }
     }
 }


### PR DESCRIPTION
Fixes a small issue with numeric sample generation that caused sample table output to contain `null` for numeric values. 