### PR TITLE
INestedContainer lifetime

### DIFF
--- a/src/explorer.api/Exploration/ExplorationRegistry.cs
+++ b/src/explorer.api/Exploration/ExplorationRegistry.cs
@@ -93,6 +93,7 @@ namespace Explorer.Api
                     if (disposing)
                     {
                         tokenSource.Dispose();
+                        Exploration.Dispose();
                     }
                     disposedValue = true;
                 }

--- a/src/explorer/ColumnExploration.cs
+++ b/src/explorer/ColumnExploration.cs
@@ -1,17 +1,22 @@
 namespace Explorer
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
     using Explorer.Metrics;
+    using Lamar;
 
-    public sealed class ColumnExploration
+    public sealed class ColumnExploration : IDisposable
     {
         private readonly MetricsPublisher publisher;
+        private readonly INestedContainer scope;
+        private bool disposedValue;
 
-        public ColumnExploration(ExplorationConfig config, MetricsPublisher publisher, string column)
+        public ColumnExploration(ExplorationConfig config, INestedContainer scope, string column)
         {
-            this.publisher = publisher;
+            this.scope = scope;
+            publisher = scope.GetInstance<MetricsPublisher>();
             Column = column;
             Completion = Task.WhenAll(config.Tasks);
         }
@@ -21,5 +26,23 @@ namespace Explorer
         public Task Completion { get; }
 
         public IEnumerable<ExploreMetric> PublishedMetrics => publisher.PublishedMetrics;
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    scope.Dispose();
+                }
+                disposedValue = true;
+            }
+        }
     }
 }

--- a/src/explorer/Exploration.cs
+++ b/src/explorer/Exploration.cs
@@ -1,6 +1,7 @@
 namespace Explorer
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;

--- a/src/explorer/Exploration.cs
+++ b/src/explorer/Exploration.cs
@@ -1,13 +1,14 @@
 namespace Explorer
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
 
-    public sealed class Exploration
+    public sealed class Exploration : IDisposable
     {
+        private bool disposedValue;
+
         public Exploration(string dataSource, string table, IList<ColumnExploration> columnExplorations)
         {
             DataSource = dataSource;
@@ -45,6 +46,12 @@ namespace Explorer
             }
         }
 
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
         private static ExplorationStatus ConvertToExplorationStatus(TaskStatus status)
         {
             return status switch
@@ -59,6 +66,21 @@ namespace Explorer
                 TaskStatus.WaitingForChildrenToComplete => ExplorationStatus.Processing,
                 _ => throw new Exception("Unexpected TaskStatus: '{exploration.Status}'."),
             };
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    foreach (var item in ColumnExplorations)
+                    {
+                        item.Dispose();
+                    }
+                }
+                disposedValue = true;
+            }
         }
     }
 }

--- a/src/explorer/ExplorationLauncher.cs
+++ b/src/explorer/ExplorationLauncher.cs
@@ -39,7 +39,7 @@ namespace Explorer
             config.UseConnection(conn);
             config.UseContext(ctx);
             config.Compose(componentConfiguration);
-            return new ColumnExploration(config, scope.GetInstance<MetricsPublisher>(), ctx.Column);
+            return new ColumnExploration(config, scope, ctx.Column);
         }
 
         /// <summary>

--- a/src/explorer/ExplorationLauncher.cs
+++ b/src/explorer/ExplorationLauncher.cs
@@ -57,8 +57,7 @@ namespace Explorer
             Action<ExplorationConfig> componentConfiguration)
         {
             // This scope (and all the components resolved within) should live until the end of the Task.
-            using var scope = rootContainer.GetNestedContainer();
-            return ExploreColumn(scope, conn, ctx, componentConfiguration);
+            return ExploreColumn(rootContainer.GetNestedContainer(), conn, ctx, componentConfiguration);
         }
 
         /// <summary>


### PR DESCRIPTION
Modified ColumnExploration to own the INestedContainer in order to correctly dispose INestedContainer objects created in ExplorationLauncher.