### PR TITLE
Update to latest remote containers definitions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,23 +3,63 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DOTNETCORE_VERSION=3.1
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
+ARG VARIANT="3.1-bionic"
+FROM mcr.microsoft.com/dotnet/core/sdk:${VARIANT}
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Options for common package install script
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="true"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SHA="dev-mode"
+
+# [Optional] Settings for installing Node.js.
+ARG INSTALL_NODE="true"
+ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/node-debian.sh"
+ARG NODE_SCRIPT_SHA="dev-mode"
+ARG NODE_VERSION="lts/*"
+ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
+
+# [Optional] Install the Azure CLI
+ARG INSTALL_AZURE_CLI="false"
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && export DEBIAN_FRONTEND=noninteractive \
     #
-    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    # Verify git, common tools / libs installed, add/modify non-root user, optionally install zsh
+    && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
+    && curl -sSL ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
+    && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
+    && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    #
+    # [Optional] Install Node.js for ASP.NET Core Web Applicationss
+    && if [ "$INSTALL_NODE" = "true" ]; then \
+        curl -sSL ${NODE_SCRIPT_SOURCE} -o /tmp/node-setup.sh \
+        && ([ "${NODE_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/node-setup.sh" | sha256sum -c -)) \
+        && /bin/bash /tmp/node-setup.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; \
+    fi \
+    #
+    # [Optional] Install the Azure CLI
+    && if [ "$INSTALL_AZURE_CLI" = "true" ]; then \
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
     #
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
+    && rm -f /tmp/common-setup.sh /tmp/node-setup.sh \
     && rm -rf /var/lib/apt/lists/*
-
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,14 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
 // https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnetcore-3.0
 {
-	"name": "C# (.NET Core 3.1)",
-	"dockerFile": "Dockerfile",
+	"name": "C# (.NET Core)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "3.1-bionic",
+			"INSTALL_NODE": "false"
+		}
+	},
 	// Use 'settings' to set *default* container specific settings.json values on container create. 
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": {
@@ -12,25 +18,25 @@
 	// "postCreateCommand": "dotnet restore",
 	// Use 'appPort' to create a container with published ports. If the port isn't working, be sure
 	// your server accepts connections from all interfaces (0.0.0.0 or '*'), not just localhost.
-	"appPort": [
+	"forwardPorts": [
 		5000,
 		5001
 	],
-	// [Optional] To reuse of your local HTTPS dev cert, first export it locally using this command: 
+	// [Optional] To reuse of your local HTTPS dev cert, first export it locally using this command:
 	//  * Windows PowerShell:
-	//     dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere" 
+	//     dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
 	//  * macOS/Linux terminal:
 	//     dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
 	//
-	// Next, after running the command above, uncomment lines in the 'mounts' and 'remoteEnv' lines below, 
+	// Next, after running the command above, uncomment lines in the 'mounts' and 'remoteEnv' lines below,
 	// and open / rebuild the container so the settings take effect.
 	//
 	"mounts": [
 		// "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind"
 	],
 	"remoteEnv": {
-		// [Optional] Override the default HTTP endpoints - need to listen to '*' for appPort to work
-		"ASPNETCORE_Kestrel__Endpoints__Http__Url": "http://*:5000",
+		// "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+		// "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
 		// A development api key can be imported from the local environment
 		"Explorer__AircloakApiKey": "${localEnv:AIRCLOAK_API_KEY}"
 	},
@@ -40,5 +46,7 @@
 		"k--kato.docomment",
 		"jchannon.csharpextensions",
 		"jorgeserrano.vscode-csharp-snippets"
-	]
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "dotnet restore"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,7 @@
     "configurations": [
         {
             "name": "explorer.api",
+            "console": "integratedTerminal",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",


### PR DESCRIPTION
The remote containers extension for dotnet has been updated. This brings the definitions in this project's .devcontainers folder up to date with the latests changes and recommendations. Notable changes:
- Use `forwardPorts` instead of `appPort` for better interop with Asp.Net
- Add `dotnet restore` as a `postCreateCommand` 
- Use `integratedTerminal` as the console in launch.json (recommended by the dotnet remote container dev team for some reason)