### PR TITLE
Daniel/add sentry

### DIFF
--- a/src/explorer.api/Program.cs
+++ b/src/explorer.api/Program.cs
@@ -27,6 +27,7 @@ namespace Explorer.Api
                 {
                     builder.UseStartup<Startup>();
                     builder.UseConfiguration(config);
+                    builder.UseSentry();
 
                     builder.ConfigureServices((_, services) => services.AddControllers());
                 });

--- a/src/explorer.api/appsettings.Development.json
+++ b/src/explorer.api/appsettings.Development.json
@@ -9,5 +9,15 @@
       "Microsoft": "Debug",
       "Microsoft.Hosting.Lifetime": "Debug"
     }
+  },
+  "Sentry": {
+    "Dsn": "https://878ce112ddf94413ab7418e6ab5503ea@o375362.ingest.sentry.io/5339378",
+    "IncludeRequestPayload": false,
+    "SendDefaultPii": false,
+    "MinimumBreadcrumbLevel": "Information",
+    "MinimumEventLevel": "Warning",
+    "AttachStackTrace": true,
+    "Debug": true,
+    "DiagnosticsLevel": "Error"
   }
 }

--- a/src/explorer.api/appsettings.json
+++ b/src/explorer.api/appsettings.json
@@ -16,8 +16,6 @@
     "SendDefaultPii": false,
     "MinimumBreadcrumbLevel": "Information",
     "MinimumEventLevel": "Warning",
-    "AttachStackTrace": true,
-    "Debug": true,
-    "DiagnosticsLevel": "Error"
+    "AttachStackTrace": true
   }
 }

--- a/src/explorer.api/appsettings.json
+++ b/src/explorer.api/appsettings.json
@@ -11,6 +11,7 @@
   },
   "AllowedHosts": "*",
   "Sentry": {
+    "Dsn": "https://878ce112ddf94413ab7418e6ab5503ea@o375362.ingest.sentry.io/5339378",
     "IncludeRequestPayload": false,
     "SendDefaultPii": false,
     "MinimumBreadcrumbLevel": "Information",

--- a/src/explorer.api/appsettings.json
+++ b/src/explorer.api/appsettings.json
@@ -9,5 +9,14 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Sentry": {
+    "IncludeRequestPayload": false,
+    "SendDefaultPii": false,
+    "MinimumBreadcrumbLevel": "Information",
+    "MinimumEventLevel": "Warning",
+    "AttachStackTrace": true,
+    "Debug": true,
+    "DiagnosticsLevel": "Error"
+  }
 }

--- a/src/explorer.api/explorer.api.csproj
+++ b/src/explorer.api/explorer.api.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../aircloak/aircloak.csproj"/>
-    <ProjectReference Include="../explorer/explorer.csproj"/>
+    <ProjectReference Include="../aircloak/aircloak.csproj" />
+    <ProjectReference Include="../explorer/explorer.csproj" />
   </ItemGroup>
   
   <ItemGroup>
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Sentry.AspNetCore" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adding sentry for issue tracking to see how useful it is.

( See issue #201 )

Quick explanation of the proposed configuration:
- `"IncludeRequestPayload": false`: in most cases we won't be able to retrieve a request payload since the exploration runs apart from the actual request.
- `"MinimumBreadcrumbLevel": "Information"`: Means that anything logged at the information level or above will be recorded for inclusion in events sent to sentry.
- `"MinimumEventLevel": "Warning"`: This means that logging a warning will send an event to sentry. 

- The following is included in the development environment only to add additional debug information:
    ```json
    "Debug": true,
    "DiagnosticsLevel": "Error"
    ```