### PR TITLE
Fix git version info for docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 **/.devcontainer
 **/.dockerignore
 **/.env
-**/.git
 **/.gitignore
 **/.project
 **/.settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
+ARG BUILD_LOG=/var/log/explorer-build.log
+
 # https://hub.docker.com/_/microsoft-dotnet-core
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 
-ENV BUILD_TARGET src/explorer.api/explorer.api.csproj
-ENV BUILD_LOG /var/log/explorer-build.log
+ARG BUILD_LOG
+ARG BUILD_TARGET=src/explorer.api/explorer.api.csproj
 
 # copy the csproj files and restore as distinct layers
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache
-COPY src/diffix/*.csproj /src/diffix/	
-COPY src/aircloak/*.csproj /src/aircloak/	
-COPY src/explorer/*.csproj /src/explorer/	
-COPY src/explorer.api/*.csproj /src/explorer.api/
+WORKDIR /build
+COPY src/diffix/*.csproj src/diffix/	
+COPY src/aircloak/*.csproj src/aircloak/	
+COPY src/explorer/*.csproj src/explorer/	
+COPY src/explorer.api/*.csproj src/explorer.api/
 RUN dotnet restore $BUILD_TARGET
 
 # copy everything else
@@ -20,6 +23,9 @@ RUN dotnet publish $BUILD_TARGET -c release -o /app --no-restore > $BUILD_LOG
 # final stage/image
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
+ARG BUILD_LOG
+
 WORKDIR /app
 COPY --from=build /app ./
+COPY --from=build $BUILD_LOG $BUILD_LOG
 ENTRYPOINT ["dotnet", "explorer.api.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ RUN dotnet publish $BUILD_TARGET -c release -o /app --no-restore > $BUILD_LOG
 # final stage/image
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
-ENV Explorer__CommitHash=$COMMIT_HASH
-ENV Explorer__CommitRef=$COMMIT_REF
-
 WORKDIR /app
 COPY --from=build /app ./
 ENTRYPOINT ["dotnet", "explorer.api.dll"]

--- a/src/explorer.api/ExplorerConfig.cs
+++ b/src/explorer.api/ExplorerConfig.cs
@@ -16,10 +16,6 @@ namespace Explorer.Api
 
         public TimeSpan PollFrequencyTimeSpan => TimeSpan.FromMilliseconds(PollFrequency);
 
-        public string? CommitHash { get; set; }
-
-        public string CommitRef { get; set; } = string.Empty;
-
         public Task<string> GetAuthToken() => Task.FromResult(AircloakApiKey);
     }
 }


### PR DESCRIPTION
The git version info wasn't showing correctly when building with docker. This was because the .git directory was included in the `.dockerignore` file, meaning the build stage had no access to git info.

Also: removes some old metadata fields from `ExplorerConfig`.

Fixes #205 