### PR TITLE
Remove Sentry for development environment

### DIFF
--- a/src/explorer.api/appsettings.Development.json
+++ b/src/explorer.api/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "Explorer": {
     "DefaultApiUrl": "https://attack.aircloak.com/api/",
-    "PollFrequency": 2020,
+    "PollFrequency": 2020
   },
   "Logging": {
     "LogLevel": {
@@ -9,15 +9,5 @@
       "Microsoft": "Debug",
       "Microsoft.Hosting.Lifetime": "Debug"
     }
-  },
-  "Sentry": {
-    "Dsn": "https://878ce112ddf94413ab7418e6ab5503ea@o375362.ingest.sentry.io/5339378",
-    "IncludeRequestPayload": false,
-    "SendDefaultPii": false,
-    "MinimumBreadcrumbLevel": "Information",
-    "MinimumEventLevel": "Warning",
-    "AttachStackTrace": true,
-    "Debug": true,
-    "DiagnosticsLevel": "Error"
   }
 }


### PR DESCRIPTION
I suppose it is not really useful to pass all the exceptions that we encounter during development in Sentry, so I removed Sentry settings from `appSettings.Development.json`.