### PR TITLE
Get min and max from histogram

### DIFF
--- a/src/explorer.api/Exploration/ComponentComposition.cs
+++ b/src/explorer.api/Exploration/ComponentComposition.cs
@@ -42,7 +42,8 @@ namespace Explorer.Api
 
         private static void NumericExploration(ExplorationConfig config)
         {
-            config.AddPublisher<NumericHistogramComponent>();
+            config.AddPublisher<HistogramSelectorComponent>();
+            config.AddPublisher<MinMaxFromHistogramComponent>();
             config.AddPublisher<QuartileEstimator>();
             config.AddPublisher<AverageEstimator>();
             config.AddPublisher<MinMaxRefiner>();

--- a/src/explorer.api/Startup.cs
+++ b/src/explorer.api/Startup.cs
@@ -11,6 +11,7 @@ namespace Explorer.Api
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
 
     public class Startup
     {
@@ -83,8 +84,10 @@ namespace Explorer.Api
         {
             var container = (IContainer)app.ApplicationServices;
 
-            System.Console.WriteLine(container.WhatDoIHave());
-            System.Console.WriteLine(container.WhatDidIScan());
+            var logger = container.GetInstance<ILogger<Startup>>();
+
+            logger.LogInformation(container.WhatDoIHave());
+            logger.LogInformation(container.WhatDidIScan());
 
             container.AssertConfigurationIsValid();
         }

--- a/src/explorer/Common/Histogram.cs
+++ b/src/explorer/Common/Histogram.cs
@@ -12,7 +12,7 @@ namespace Explorer.Common
         {
             Debug.Assert(
                 buckets.All(b => b.BucketSize.SnappedSize == bucketSize.SnappedSize),
-                $"Histogram buckets don't match given bucketsize");
+                "Histogram buckets don't match given bucketsize");
 
             BucketSize = bucketSize;
             Buckets = new SortedList<decimal, HistogramBucket>(buckets.ToDictionary(b => b.LowerBound));
@@ -21,6 +21,10 @@ namespace Explorer.Common
         public BucketSize BucketSize { get; }
 
         public SortedList<decimal, HistogramBucket> Buckets { get; }
+
+        public (decimal, decimal) Bounds => (
+                    Buckets.First().Value.LowerBound,
+                    Buckets.Last().Value.LowerBound + BucketSize.SnappedSize);
 
         public static IEnumerable<Histogram> FromQueryRows(IEnumerable<SingleColumnHistogram.Result> queryResults) =>
             from row in queryResults

--- a/src/explorer/Components/AverageEstimator.cs
+++ b/src/explorer/Components/AverageEstimator.cs
@@ -5,20 +5,21 @@ namespace Explorer.Components
     using System.Threading.Tasks;
 
     using Explorer.Common;
+    using Explorer.Components.ResultTypes;
     using Explorer.Metrics;
 
     public class AverageEstimator :
         ExplorerComponent<AverageEstimator.Result>, PublisherComponent
     {
-        private readonly ResultProvider<NumericHistogramComponent.Result> histogramResultProvider;
+        private readonly ResultProvider<HistogramWithCounts> histogramResultProvider;
 
-        public AverageEstimator(ResultProvider<NumericHistogramComponent.Result> histogramResultProvider)
+        public AverageEstimator(ResultProvider<HistogramWithCounts> histogramResultProvider)
         {
             this.histogramResultProvider = histogramResultProvider;
         }
 
-        public static Task<decimal> EstimateAverage(NumericHistogramComponent.Result result) =>
-            EstimateAverage(result.Histogram);
+        public static Task<decimal> EstimateAverage(HistogramWithCounts hwc) =>
+            EstimateAverage(hwc.Histogram);
 
         public static Task<decimal> EstimateAverage(Histogram histogram) => Task.Run(() =>
         {

--- a/src/explorer/Components/HistogramSelectorComponent.cs
+++ b/src/explorer/Components/HistogramSelectorComponent.cs
@@ -1,0 +1,55 @@
+namespace Explorer.Components
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Explorer.Components.ResultTypes;
+    using Explorer.Metrics;
+
+    public class HistogramSelectorComponent :
+        ExplorerComponent<HistogramWithCounts>, PublisherComponent
+    {
+        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
+        private readonly ResultProvider<List<HistogramWithCounts>> histogramsProvider;
+
+        public HistogramSelectorComponent(
+            ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
+            ResultProvider<List<HistogramWithCounts>> histogramsProvider)
+        {
+            this.distinctValuesProvider = distinctValuesProvider;
+            this.histogramsProvider = histogramsProvider;
+        }
+
+        public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
+        {
+            var distinctValues = await distinctValuesProvider.ResultAsync;
+
+            if (!distinctValues.IsCategorical)
+            {
+                var result = await ResultAsync;
+
+                yield return new UntypedMetric("histogram.buckets", result.Histogram.Buckets.Values.Select(b => new
+                {
+                    BucketSize = b.BucketSize.SnappedSize,
+                    b.LowerBound,
+                    b.Count,
+                    b.CountNoise,
+                }));
+                yield return new UntypedMetric("histogram.suppressed_count", result.ValueCounts.SuppressedCount);
+                yield return new UntypedMetric("histogram.suppressed_ratio", result.ValueCounts.SuppressedCountRatio);
+                yield return new UntypedMetric("histogram.value_counts", result.ValueCounts);
+            }
+        }
+
+        protected override async Task<HistogramWithCounts> Explore()
+        {
+            var histograms = await histogramsProvider.ResultAsync;
+
+            return histograms
+                .OrderBy(h => h.BucketSize.SnappedSize)
+                .ThenBy(h => h.ValueCounts.SuppressedCount)
+                .First();
+        }
+    }
+}

--- a/src/explorer/Components/MinMaxFromHistogramComponent.cs
+++ b/src/explorer/Components/MinMaxFromHistogramComponent.cs
@@ -1,0 +1,51 @@
+namespace Explorer.Components
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Explorer.Components.ResultTypes;
+    using Explorer.Metrics;
+
+    public class MinMaxFromHistogramComponent :
+        ExplorerComponent<MinMaxFromHistogramComponent.Result>, PublisherComponent
+    {
+        private readonly ResultProvider<List<HistogramWithCounts>> histogramsProvider;
+
+        public MinMaxFromHistogramComponent(ResultProvider<List<HistogramWithCounts>> histogramsProvider)
+        {
+            this.histogramsProvider = histogramsProvider;
+        }
+
+        public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
+        {
+            var bounds = await ResultAsync;
+
+            if (!(bounds is null))
+            {
+                yield return new UntypedMetric("min", bounds.Min, priority: 10);
+                yield return new UntypedMetric("max", bounds.Max, priority: 10);
+            }
+        }
+
+        protected override async Task<Result> Explore()
+        {
+            var histograms = await histogramsProvider.ResultAsync;
+
+            return histograms
+                .Where(r => r.ValueCounts.SuppressedCount == 0)
+                .OrderBy(r => r.BucketSize.SnappedSize)
+                .Take(1)
+                .Select(r => new Result(r.Histogram.Bounds))
+                .SingleOrDefault();
+        }
+
+        public class Result : NumericColumnBounds
+        {
+            internal Result((decimal, decimal) bounds)
+            : base(bounds.Item1, bounds.Item2)
+            {
+            }
+        }
+    }
+}

--- a/src/explorer/Components/NumericDistributionComponent.cs
+++ b/src/explorer/Components/NumericDistributionComponent.cs
@@ -6,12 +6,13 @@
 
     using Accord.Statistics.Distributions.Univariate;
     using Explorer.Common;
+    using Explorer.Components.ResultTypes;
 
     public class NumericDistributionComponent : ExplorerComponent<NumericDistribution>
     {
-        private readonly ResultProvider<NumericHistogramComponent.Result> histogramResultProvider;
+        private readonly ResultProvider<HistogramWithCounts> histogramResultProvider;
 
-        public NumericDistributionComponent(ResultProvider<NumericHistogramComponent.Result> histogramResultProvider)
+        public NumericDistributionComponent(ResultProvider<HistogramWithCounts> histogramResultProvider)
         {
             this.histogramResultProvider = histogramResultProvider;
         }

--- a/src/explorer/Components/NumericHistogramComponent.cs
+++ b/src/explorer/Components/NumericHistogramComponent.cs
@@ -6,54 +6,28 @@ namespace Explorer.Components
 
     using Diffix;
     using Explorer.Common;
-    using Explorer.Metrics;
+    using Explorer.Components.ResultTypes;
     using Explorer.Queries;
 
     public class NumericHistogramComponent :
-        ExplorerComponent<NumericHistogramComponent.Result>, PublisherComponent
+        ExplorerComponent<List<HistogramWithCounts>>
     {
         private const long ValuesPerBucketTarget = 20;
         private readonly DConnection conn;
         private readonly ExplorerContext ctx;
-        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
         private readonly ResultProvider<SimpleStats<double>.Result> statsResultProvider;
 
         public NumericHistogramComponent(
             DConnection conn,
             ExplorerContext ctx,
-            ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
             ResultProvider<SimpleStats<double>.Result> statsResultProvider)
         {
             this.conn = conn;
             this.ctx = ctx;
-            this.distinctValuesProvider = distinctValuesProvider;
             this.statsResultProvider = statsResultProvider;
         }
 
-        public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
-        {
-            var distinctValues = await distinctValuesProvider.ResultAsync;
-            if (!distinctValues.IsCategorical)
-            {
-                var result = await ResultAsync;
-
-                if (result.Histogram.Buckets.Count > 0)
-                {
-                    yield return new UntypedMetric("histogram.buckets", result.Histogram.Buckets.Values.Select(b => new
-                    {
-                        BucketSize = b.BucketSize.SnappedSize,
-                        b.LowerBound,
-                        b.Count,
-                        b.CountNoise,
-                    }));
-                    yield return new UntypedMetric("histogram.suppressed_count", result.ValueCounts.SuppressedCount);
-                    yield return new UntypedMetric("histogram.suppressed_ratio", result.ValueCounts.SuppressedCountRatio);
-                    yield return new UntypedMetric("histogram.value_counts", result.ValueCounts);
-                }
-            }
-        }
-
-        protected async override Task<Result> Explore()
+        protected async override Task<List<HistogramWithCounts>> Explore()
         {
             var stats = await statsResultProvider.ResultAsync;
 
@@ -73,31 +47,13 @@ namespace Explorer.Components
                     row => row.BucketSize,
                     (bs, rows) => (BucketSize: new BucketSize(bs), Rows: ValueCounts.Compute(rows)));
 
-            var results = valueCounts.Join(
-                histograms,
-                v => v.BucketSize.SnappedSize,
-                h => h.BucketSize.SnappedSize,
-                (v, h) => new Result(v.Rows, h));
-
-            return results
-                .OrderBy(h => h.BucketSize.SnappedSize)
-                .ThenBy(h => h.ValueCounts.SuppressedCount)
-                .First();
-        }
-
-        public class Result
-        {
-            internal Result(ValueCounts valueCounts, Histogram histogram)
-            {
-                ValueCounts = valueCounts;
-                Histogram = histogram;
-            }
-
-            public BucketSize BucketSize => Histogram.BucketSize;
-
-            public ValueCounts ValueCounts { get; }
-
-            public Histogram Histogram { get; }
+            return valueCounts
+                .Join(
+                    histograms,
+                    v => v.BucketSize.SnappedSize,
+                    h => h.BucketSize.SnappedSize,
+                    (v, h) => new HistogramWithCounts(v.Rows, h))
+                .ToList();
         }
     }
 }

--- a/src/explorer/Components/QuartileEstimator.cs
+++ b/src/explorer/Components/QuartileEstimator.cs
@@ -5,24 +5,25 @@ namespace Explorer.Components
     using System.Threading.Tasks;
 
     using Explorer.Common;
+    using Explorer.Components.ResultTypes;
     using Explorer.Metrics;
 
     public class QuartileEstimator :
         ExplorerComponent<QuartileEstimator.Result>, PublisherComponent
     {
         private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
-        private readonly ResultProvider<NumericHistogramComponent.Result> histogramResult;
+        private readonly ResultProvider<HistogramWithCounts> histogramResult;
 
         public QuartileEstimator(
             ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
-            ResultProvider<NumericHistogramComponent.Result> histogramResult)
+            ResultProvider<HistogramWithCounts> histogramResult)
         {
             this.distinctValuesProvider = distinctValuesProvider;
             this.histogramResult = histogramResult;
         }
 
-        public static Task<List<double>> EstimateQuartiles(NumericHistogramComponent.Result result) =>
-            EstimateQuartiles(result.Histogram);
+        public static Task<List<double>> EstimateQuartiles(HistogramWithCounts hwc) =>
+            EstimateQuartiles(hwc.Histogram);
 
         public static Task<List<double>> EstimateQuartiles(Histogram histogram) => Task.Run(() =>
         {

--- a/src/explorer/Components/ResultTypes/HistogramWithCounts.cs
+++ b/src/explorer/Components/ResultTypes/HistogramWithCounts.cs
@@ -1,0 +1,19 @@
+namespace Explorer.Components.ResultTypes
+{
+    using Explorer.Common;
+
+    public class HistogramWithCounts
+    {
+        internal HistogramWithCounts(ValueCounts valueCounts, Histogram histogram)
+        {
+            ValueCounts = valueCounts;
+            Histogram = histogram;
+        }
+
+        public BucketSize BucketSize => Histogram.BucketSize;
+
+        public ValueCounts ValueCounts { get; }
+
+        public Histogram Histogram { get; }
+    }
+}

--- a/src/explorer/Components/ResultTypes/NumericColumnBounds.cs
+++ b/src/explorer/Components/ResultTypes/NumericColumnBounds.cs
@@ -1,0 +1,17 @@
+namespace Explorer.Components.ResultTypes
+{
+    public class NumericColumnBounds
+    {
+        internal NumericColumnBounds(decimal min, decimal max)
+        {
+            Max = max;
+            Min = min;
+        }
+
+        public decimal Min { get; }
+
+        public decimal Max { get; }
+
+        public bool IsZero => Min == 0 && Max == 0;
+    }
+}

--- a/src/explorer/Components/SimpleStats.cs
+++ b/src/explorer/Components/SimpleStats.cs
@@ -26,8 +26,8 @@ namespace Explorer.Components
             var result = await ResultAsync;
 
             yield return new UntypedMetric("count", result.Count);
-            yield return new UntypedMetric("naive_min", result.Min!);
-            yield return new UntypedMetric("naive_max", result.Max!);
+            yield return new UntypedMetric("min", result.Min!);
+            yield return new UntypedMetric("max", result.Max!);
         }
 
         protected override async Task<SimpleStats<T>.Result> Explore()

--- a/src/explorer/Metrics/ExploreMetric.cs
+++ b/src/explorer/Metrics/ExploreMetric.cs
@@ -5,5 +5,7 @@ namespace Explorer.Metrics
         public string Name { get; }
 
         public object Metric { get; }
+
+        public int Priority { get; }
     }
 }

--- a/src/explorer/Metrics/SimpleMetricsPublisher.cs
+++ b/src/explorer/Metrics/SimpleMetricsPublisher.cs
@@ -21,7 +21,10 @@ namespace Explorer.Metrics
         public void PublishMetric(ExploreMetric metric)
         {
             logger.LogDebug($"{nameof(SimpleMetricsPublisher)}: Publishing metric {metric.Name}.");
-            store[metric.Name] = metric;
+            store.AddOrUpdate(
+                metric.Name,
+                _ => metric,
+                (_, old) => metric.Priority >= old.Priority ? metric : old);
         }
     }
 }

--- a/src/explorer/Metrics/UntypedMetric.cs
+++ b/src/explorer/Metrics/UntypedMetric.cs
@@ -1,15 +1,21 @@
 namespace Explorer.Metrics
 {
+    using System.Text.Json.Serialization;
+
     public struct UntypedMetric : ExploreMetric
     {
-        public UntypedMetric(string name, object metric)
+        public UntypedMetric(string name, object metric, int priority = 0)
         {
             Name = name;
             Metric = metric;
+            Priority = priority;
         }
 
         public string Name { get; }
 
         public object Metric { get; }
+
+        [JsonIgnore]
+        public int Priority { get; }
     }
 }

--- a/tests/explorer.tests/ComponentTests.cs
+++ b/tests/explorer.tests/ComponentTests.cs
@@ -113,6 +113,25 @@ namespace Explorer.Tests
             });
         }
 
+        [Fact]
+        public async Task TestHistogramMinMaxComponent()
+        {
+            using var scope = testFixture.SimpleComponentTestScope(
+                "gda_banking",
+                "loans",
+                "duration",
+                new DColumnInfo(DValueType.Integer, DColumnInfo.ColumnType.Regular),
+                vcrFilename: ExplorerTestFixture.GenerateVcrFilename(this));
+
+            await scope.ResultTest<MinMaxFromHistogramComponent, MinMaxFromHistogramComponent.Result>(result =>
+            {
+                const decimal expectedMin = 12.0M;
+                const decimal expectedMax = 61.0M;
+                Assert.True(result.Min == expectedMin, $"Expected {expectedMin}, got {result.Min}");
+                Assert.True(result.Max == expectedMax, $"Expected {expectedMax}, got {result.Max}");
+            });
+        }
+
         private void CheckDistinctCategories<T>(
             DistinctValuesComponent.Result distinctValuesResult,
             IEnumerable<ValueWithCount<T>> expectedValues,

--- a/tests/explorer.tests/Setup/QueryableTestScope.cs
+++ b/tests/explorer.tests/Setup/QueryableTestScope.cs
@@ -19,6 +19,16 @@ namespace Explorer.Tests
 
         public TestScope Inner { get; }
 
+        public DConnection Conn
+        {
+            get => Inner.Scope.GetInstance<DConnection>();
+        }
+
+        public ExplorerContext Ctx
+        {
+            get => Inner.Scope.GetInstance<ExplorerContext>();
+        }
+
         public async Task<IEnumerable<TRow>> QueryRows<TRow>(DQuery<TRow> query)
         {
             var queryResult = await Inner.Scope.GetInstance<DConnection>().Exec(query);


### PR DESCRIPTION
If the computed histogram for numeric column has no suppressed values, use the histogram to estimate the `min` and `max` for the column. If this is not possible, use the `MinMaxRefinerComponent` to estimate an improved `min` and `max` as before. 

This PR also adds the possibility to prioritize metrics by adding a `priority` argument. The highest priority metric with the same name is the one that is published. This is used to publish `min` and `max` and replace them as more accurate values become available. 

Fixes #166 
