### PR TITLE
Add api versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,18 @@ docker run -it --rm -p 5000:80 explorer
 
 > You will need an access token for the Aircloak API. If you don't have one, ask your local Aircloak admin.
 
+### Api Versions
+
+All endpoints are versioned under an api schema root. The api root is `/api/vN`, where N is the
+version number. At present, the api is at version 1 so the url root is `/api/v1`.
+
 ### Launching an exploration
 
 Diffix Explorer exposes an `/explore` endpoint that expects a `POST` request containing the url of the Aircloak API,
-and authentication token, and the dataset, table and column to analyse. Assuming you are running the Explorer on `localhost:5000` and you are targeting `https://attack.aircloak.com/api/`:
+and authentication token, and the dataset, table and column to analyse. Assuming you are running the Explorer on `localhost:5000` and you are targeting an Aircloak backend api at `https://attack.aircloak.com/api/`:
 
 ```bash
-curl -k -X POST -H "Content-Type: application/json" http://localhost:5000/explore \
+curl -k -X POST -H "Content-Type: application/json" http://localhost:5000/api/v1/explore \
   -d "{
    \"ApiUrl\":\"https://attack.aircloak.com/api/\"
    \"ApiKey\":\"my_secret_key\",
@@ -124,7 +129,7 @@ This launches the column exploration and, if all goes well, returns a http 200 r
 
 You can use the exploration `id` to poll for results on the `/result` endpoint:
 ```bash
-curl -k http://localhost:5000/result/204f47b4-9c9d-46d2-bdb0-95ef3d61f8cf
+curl -k http://localhost:5000/api/v1/result/204f47b4-9c9d-46d2-bdb0-95ef3d61f8cf
 ```
 
 The body of the response should again contain a json payload with an indication of the processing status as well as any computed metrics, e.g. for integer and text columns:
@@ -234,7 +239,7 @@ When exploration is complete, this is indicated with `"status": "Complete"`.
 You can cancel an ongoing exploration using the (you guessed it) `/cancel` endpoint:
 
 ```bash
-curl -k http://localhost:5000/cancel/204f47b4-9c9d-46d2-bdb0-95ef3d61f8cf
+curl -k http://localhost:5000/api/v1/cancel/204f47b4-9c9d-46d2-bdb0-95ef3d61f8cf
 ```
 
 ### More examples

--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -29,8 +29,9 @@ namespace Explorer.Api.Controllers
             this.explorationRegistry = explorationRegistry;
         }
 
+        [ApiVersion("1.0")]
         [HttpPost]
-        [Route("explore")]
+        [Route("api/v{version:apiVersion}/explore")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Explore(
@@ -59,8 +60,9 @@ namespace Explorer.Api.Controllers
             return Ok(new ExploreResult(id, ExplorationStatus.New, data.DataSource, data.Table));
         }
 
+        [ApiVersion("1.0")]
         [HttpGet]
-        [Route("result/{explorationId}")]
+        [Route("api/v{version:apiVersion}/result/{explorationId}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Result(
@@ -115,8 +117,9 @@ namespace Explorer.Api.Controllers
             return Ok(exploreResult);
         }
 
+        [ApiVersion("1.0")]
         [HttpGet]
-        [Route("cancel/{explorationId}")]
+        [Route("api/v{version:apiVersion}/cancel/{explorationId}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public IActionResult Cancel(Guid explorationId)

--- a/src/explorer.api/Startup.cs
+++ b/src/explorer.api/Startup.cs
@@ -28,6 +28,7 @@ namespace Explorer.Api
         public void ConfigureContainer(ServiceRegistry services)
         {
             services.AddControllers();
+            services.AddApiVersioning();
 
             var config = Configuration.GetSection("Explorer").Get<ExplorerConfig>();
             services.AddSingleton(config);

--- a/src/explorer.api/explorer.api.csproj
+++ b/src/explorer.api/explorer.api.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Sentry.AspNetCore" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/explorer.api.tests/ApiTests.cs
+++ b/tests/explorer.api.tests/ApiTests.cs
@@ -257,7 +257,7 @@
         {
             await TestApi(
                 HttpMethod.Get,
-                $"{resultEndpoint}/c29191e7-408e-4395-bb81-660c47181661",
+                $"{resultEndpoint}/11111111-1111-1111-1111-111111111111",
                 null,
                 test: (response, content) => Assert.True(response.StatusCode == HttpStatusCode.NotFound, content));
         }

--- a/tests/explorer.api.tests/ApiTests.cs
+++ b/tests/explorer.api.tests/ApiTests.cs
@@ -170,8 +170,14 @@
         [InlineData("/invalid endpoint test")]
         public async Task FailWithBadEndPoint(string endpoint)
         {
-            await TestApi(HttpMethod.Post, endpoint, ValidData, test: (response, content) =>
-                Assert.False(response.IsSuccessStatusCode, content));
+            var apiEndpoint = ApiRoot + endpoint;
+
+            await TestApi(HttpMethod.Post, apiEndpoint, ValidData, test: (response, content) =>
+            {
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                var jsonContent = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(content);
+                Assert.True(jsonContent.ContainsKey("error"), $"Expected an 'error' object in payload: {content}");
+            });
         }
 
         [Theory]
@@ -182,7 +188,11 @@
         public async Task FailWithBadMethod(string method)
         {
             await TestApi(new HttpMethod(method), exploreEndpoint, ValidData, test: (response, content) =>
-                Assert.False(response.IsSuccessStatusCode, content));
+            {
+                Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+                var jsonContent = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(content);
+                Assert.True(jsonContent.ContainsKey("error"), $"Expected an 'error' object in payload: {content}");
+            });
         }
 
         [Fact]

--- a/tests/explorer.api.tests/ApiTests.cs
+++ b/tests/explorer.api.tests/ApiTests.cs
@@ -252,6 +252,16 @@
                 });
         }
 
+        [Fact]
+        public async Task FailWithInvalidExplorationId()
+        {
+            await TestApi(
+                HttpMethod.Get,
+                $"{resultEndpoint}/c29191e7-408e-4395-bb81-660c47181661",
+                null,
+                test: (response, content) => Assert.True(response.StatusCode == HttpStatusCode.NotFound, content));
+        }
+
         private async Task TestExploreResult(
             HttpMethod method,
             Guid explorerGuid,


### PR DESCRIPTION
This adds api versioning.
For now there is just a version 1 - we can create version 2 once version 1 is frozen. 

Note the new base path is `/api/v1/`.

Fixes #219 