### PR TITLE
Sample values generation for categorical columns

### DIFF
--- a/src/explorer.api/Exploration/ComponentComposition.cs
+++ b/src/explorer.api/Exploration/ComponentComposition.cs
@@ -32,11 +32,12 @@ namespace Explorer.Api
         private static void CommonConfiguration(ExplorationConfig config)
         {
             config.AddPublisher<ExplorationInfo>();
+            config.AddPublisher<DistinctValuesComponent>();
+            config.AddPublisher<CategoricalSampleGenerator>();
         }
 
         private static void BoolExploration(ExplorationConfig config)
         {
-            config.AddPublisher<DistinctValuesComponent>();
         }
 
         private static void NumericExploration(ExplorationConfig config)
@@ -45,7 +46,6 @@ namespace Explorer.Api
             config.AddPublisher<QuartileEstimator>();
             config.AddPublisher<AverageEstimator>();
             config.AddPublisher<MinMaxRefiner>();
-            config.AddPublisher<DistinctValuesComponent>();
             config.AddPublisher<NumericSampleGenerator>();
             config.AddPublisher<DistributionAnalysisComponent>();
             config.AddPublisher<DescriptiveStatsPublisher>();
@@ -53,7 +53,6 @@ namespace Explorer.Api
 
         private static void TextExploration(ExplorationConfig config)
         {
-            config.AddPublisher<DistinctValuesComponent>();
             config.AddPublisher<EmailCheckComponent>();
             config.AddPublisher<TextGeneratorComponent>();
             config.AddPublisher<TextLengthComponent>();
@@ -61,7 +60,6 @@ namespace Explorer.Api
 
         private static void DatetimeExploration(ExplorationConfig config)
         {
-            config.AddPublisher<DistinctValuesComponent>();
             config.AddPublisher<LinearTimeBuckets>();
             config.AddPublisher<CyclicalTimeBuckets>();
             config.AddPublisher<DatetimeDistributionComponent>();

--- a/src/explorer/Components/CategoricalSampleGenerator.cs
+++ b/src/explorer/Components/CategoricalSampleGenerator.cs
@@ -1,0 +1,62 @@
+namespace Explorer.Components
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+
+    using Diffix;
+    using Explorer.Common;
+    using Explorer.Metrics;
+
+    public class CategoricalSampleGenerator
+        : ExplorerComponent<CategoricalSampleGenerator.Result>, PublisherComponent
+    {
+        public const int DefaultSamplesToPublish = 20;
+
+        private static readonly JsonElement JsonNullElement = JsonDocument.Parse("null").RootElement;
+        private readonly DistinctValuesComponent distinctValues;
+
+        public CategoricalSampleGenerator(DistinctValuesComponent distinctValues)
+        {
+            this.distinctValues = distinctValues;
+        }
+
+        public int NumValuesToPublish { get; set; } = DefaultSamplesToPublish;
+
+        public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
+        {
+            var result = await ResultAsync;
+            if (result.SampleValues.Count > 0)
+            {
+                yield return new UntypedMetric(name: "sample_values", metric: result.SampleValues);
+            }
+        }
+
+        protected override async Task<Result> Explore()
+        {
+            var distinctValuesResult = await distinctValues.ResultAsync;
+            var sampleValues = Enumerable.Empty<JsonElement>();
+            if (distinctValuesResult.IsCategorical)
+            {
+                var rand = new Random(Environment.TickCount);
+                var allValues = ValueWithCountList<JsonElement>.FromValueWithCountEnum(distinctValuesResult.DistinctRows);
+                sampleValues = Enumerable
+                    .Range(0, NumValuesToPublish)
+                    .Select(_ => allValues.GetRandomValue(rand, JsonNullElement));
+            }
+            return new Result(sampleValues.ToList());
+        }
+
+        public class Result
+        {
+            public Result(IList<JsonElement> sampleValues)
+            {
+                SampleValues = sampleValues;
+            }
+
+            public IList<JsonElement> SampleValues { get; }
+        }
+    }
+}

--- a/src/explorer/Components/DistributionPublishers/NumericSampleGenerator.cs
+++ b/src/explorer/Components/DistributionPublishers/NumericSampleGenerator.cs
@@ -11,12 +11,15 @@ namespace Explorer.Components
     {
         public const int DefaultSamplesToPublish = 20;
         private readonly ExplorerContext ctx;
+        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
         private readonly ResultProvider<NumericDistribution> distributionProvider;
 
         public NumericSampleGenerator(
             ExplorerContext ctx,
+            ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
             ResultProvider<NumericDistribution> distributionProvider)
         {
+            this.distinctValuesProvider = distinctValuesProvider;
             this.distributionProvider = distributionProvider;
             this.ctx = ctx;
         }
@@ -25,15 +28,19 @@ namespace Explorer.Components
 
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
         {
-            var distribution = await distributionProvider.ResultAsync;
+            var distinctValues = await distinctValuesProvider.ResultAsync;
+            if (!distinctValues.IsCategorical)
+            {
+                var distribution = await distributionProvider.ResultAsync;
 
-            yield return new UntypedMetric(
-                name: "sample_values",
-                metric: distribution
-                        .Generate(SamplesToPublish)
-                        .Select(s => ctx.ColumnInfo.Type == Diffix.DValueType.Real ? s : Convert.ToInt64(s))
-                        .OrderBy(_ => _)
-                        .ToArray());
+                yield return new UntypedMetric(
+                    name: "sample_values",
+                    metric: distribution
+                            .Generate(SamplesToPublish)
+                            .Select(s => ctx.ColumnInfo.Type == Diffix.DValueType.Real ? s : Convert.ToInt64(s))
+                            .OrderBy(_ => _)
+                            .ToArray());
+            }
         }
     }
 }

--- a/src/explorer/Components/QuartileEstimator.cs
+++ b/src/explorer/Components/QuartileEstimator.cs
@@ -10,11 +10,14 @@ namespace Explorer.Components
     public class QuartileEstimator :
         ExplorerComponent<QuartileEstimator.Result>, PublisherComponent
     {
+        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
         private readonly ResultProvider<NumericHistogramComponent.Result> histogramResult;
 
         public QuartileEstimator(
+            ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
             ResultProvider<NumericHistogramComponent.Result> histogramResult)
         {
+            this.distinctValuesProvider = distinctValuesProvider;
             this.histogramResult = histogramResult;
         }
 
@@ -77,9 +80,13 @@ namespace Explorer.Components
 
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
         {
-            var result = await ResultAsync;
+            var distinctValues = await distinctValuesProvider.ResultAsync;
+            if (!distinctValues.IsCategorical)
+            {
+                var result = await ResultAsync;
 
-            yield return new UntypedMetric(name: "quartile_estimates", metric: result.AsList);
+                yield return new UntypedMetric(name: "quartile_estimates", metric: result.AsList);
+            }
         }
 
         protected override async Task<Result> Explore() =>

--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -15,9 +15,9 @@ namespace Explorer.Components
 
     public class TextGeneratorComponent : ExplorerComponent<TextGeneratorComponent.Result>, PublisherComponent
     {
-        private const int DefaultGeneratedValuesCount = 30;
-        private const int DefaultEmailDomainsCountThreshold = 5 * DefaultGeneratedValuesCount;
-        private const int DefaultSubstringQueryColumnCount = 5;
+        public const int DefaultSamplesToPublish = 20;
+        public const int DefaultEmailDomainsCountThreshold = 5 * DefaultSamplesToPublish;
+        public const int DefaultSubstringQueryColumnCount = 5;
 
         private readonly DConnection conn;
         private readonly ExplorerContext ctx;
@@ -28,12 +28,12 @@ namespace Explorer.Components
             this.conn = conn;
             this.ctx = ctx;
             this.emailChecker = emailChecker;
-            GeneratedValuesCount = DefaultGeneratedValuesCount;
+            SamplesToPublish = DefaultSamplesToPublish;
             EmailDomainsCountThreshold = DefaultEmailDomainsCountThreshold;
             SubstringQueryColumnCount = DefaultSubstringQueryColumnCount;
         }
 
-        public int GeneratedValuesCount { get; set; }
+        public int SamplesToPublish { get; set; }
 
         public int EmailDomainsCountThreshold { get; set; }
 
@@ -208,7 +208,7 @@ namespace Explorer.Components
                 ExploreEmailTopLevelDomains(conn, ctx));
 
             return await Task.Run(() => GenerateEmails(
-                    substrings, domains, tlds, GeneratedValuesCount, EmailDomainsCountThreshold));
+                    substrings, domains, tlds, SamplesToPublish, EmailDomainsCountThreshold));
         }
 
         private async Task<IEnumerable<string>> GenerateStrings()
@@ -217,7 +217,7 @@ namespace Explorer.Components
             var substrings = await ExploreSubstrings(
                 conn, ctx, SubstringQueryColumnCount, substringLengths: new int[] { 3, 4 });
             var rand = new Random(Environment.TickCount);
-            return Enumerable.Range(0, GeneratedValuesCount).Select(_
+            return Enumerable.Range(0, SamplesToPublish).Select(_
                 => GenerateString(substrings, minLength: 3, rand));
         }
 

--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -47,6 +47,9 @@ namespace Explorer.Components
 
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
         {
+            var distinctValuesResult = await distinctValues.ResultAsync;
+            if (!distinctValuesResult.IsCategorical)
+            {
             var result = await ResultAsync;
 
             if (result.SampleValues.Count > 0)
@@ -54,18 +57,12 @@ namespace Explorer.Components
                 yield return new UntypedMetric(name: "sample_values", metric: result.SampleValues);
             }
         }
+        }
 
         protected override async Task<Result> Explore()
         {
-            var sampleValues = Enumerable.Empty<string>();
-            var distinctValuesResult = await distinctValues.ResultAsync;
-            if (!distinctValuesResult.IsCategorical)
-            {
                 var emailCheckerResult = await emailChecker.ResultAsync;
-                sampleValues = emailCheckerResult.IsEmail
-                    ? await GenerateEmails()
-                    : await GenerateStrings();
-            }
+            var sampleValues = emailCheckerResult.IsEmail ? await GenerateEmails() : await GenerateStrings();
             return new Result(sampleValues.ToList());
         }
 

--- a/tests/explorer.tests/NumericDistributionTests.cs
+++ b/tests/explorer.tests/NumericDistributionTests.cs
@@ -22,7 +22,7 @@
             using var scope = testFixture.SimpleComponentTestScope(
                 "gda_banking",
                 "loans",
-                "duration",
+                "amount",
                 new DColumnInfo(DValueType.Integer, DColumnInfo.ColumnType.Regular),
                 ExplorerTestFixture.GenerateVcrFilename(this));
 

--- a/tests/explorer.tests/TextColumnExplorerTests.cs
+++ b/tests/explorer.tests/TextColumnExplorerTests.cs
@@ -31,12 +31,12 @@ namespace Explorer.Tests
 
             await scope.ResultTest<EmailCheckComponent, EmailCheckComponent.Result>(r => Assert.True(r.IsEmail));
 
-            await scope.ResultTest<TextGeneratorComponent, IEnumerable<string>>(result =>
+            await scope.ResultTest<TextGeneratorComponent, TextGeneratorComponent.Result>(result =>
             {
-                Assert.True(result.All(v => v.Length >= 3));
-                Assert.True(result.All(v => v.Count(c => c == '@') == 1));
-                Assert.True(result.All(v => v.Contains('.', StringComparison.InvariantCulture)));
-                Assert.True(result.All(v => !v.Contains("..", StringComparison.InvariantCulture)));
+                Assert.True(result.SampleValues.All(v => v.Length >= 3));
+                Assert.True(result.SampleValues.All(v => v.Count(c => c == '@') == 1));
+                Assert.True(result.SampleValues.All(v => v.Contains('.', StringComparison.InvariantCulture)));
+                Assert.True(result.SampleValues.All(v => !v.Contains("..", StringComparison.InvariantCulture)));
             });
         }
 
@@ -52,12 +52,12 @@ namespace Explorer.Tests
 
             await scope.ResultTest<EmailCheckComponent, EmailCheckComponent.Result>(r => Assert.True(r.IsEmail));
 
-            await scope.ResultTest<TextGeneratorComponent, IEnumerable<string>>(result =>
+            await scope.ResultTest<TextGeneratorComponent, TextGeneratorComponent.Result>(result =>
             {
-                Assert.True(result.All(v => v.Length >= 3));
-                Assert.True(result.All(v => v.Count(c => c == '@') == 1));
-                Assert.True(result.All(v => v.Contains('.', StringComparison.InvariantCulture)));
-                Assert.True(result.All(v => !v.Contains("..", StringComparison.InvariantCulture)));
+                Assert.True(result.SampleValues.All(v => v.Length >= 3));
+                Assert.True(result.SampleValues.All(v => v.Count(c => c == '@') == 1));
+                Assert.True(result.SampleValues.All(v => v.Contains('.', StringComparison.InvariantCulture)));
+                Assert.True(result.SampleValues.All(v => !v.Contains("..", StringComparison.InvariantCulture)));
             });
         }
 
@@ -73,8 +73,8 @@ namespace Explorer.Tests
 
             await scope.ResultTest<EmailCheckComponent, EmailCheckComponent.Result>(r => Assert.False(r.IsEmail));
 
-            await scope.ResultTest<TextGeneratorComponent, IEnumerable<string>>(result =>
-                Assert.True(result.All(v => v.Length >= 3)));
+            await scope.ResultTest<TextGeneratorComponent, TextGeneratorComponent.Result>(result =>
+                Assert.True(result.SampleValues.All(v => v.Length >= 3)));
         }
 
         [Fact]
@@ -89,8 +89,8 @@ namespace Explorer.Tests
 
             await scope.ResultTest<EmailCheckComponent, EmailCheckComponent.Result>(r => Assert.False(r.IsEmail));
 
-            await scope.ResultTest<TextGeneratorComponent, IEnumerable<string>>(result =>
-                Assert.True(result.All(v => v.Length >= 3)));
+            await scope.ResultTest<TextGeneratorComponent, TextGeneratorComponent.Result>(result =>
+                Assert.True(result.SampleValues.All(v => v.Length >= 3)));
         }
     }
 }


### PR DESCRIPTION
- added a new component for generating sample values for categorical columns (`CategoricalSampleGenerator`) and use it correctly for categorical columns in `NumericSampleGenerator` and `TextGeneratorComponent`;
- skip histogram and quartiles computation for categorical numeric columns
- I observed some additional bugs in `ValuesWithCountList.GetRandomValue`, which I will investigate and fix with a separate PR
