### PR TITLE
Remove duplicate component invocations

### DIFF
--- a/src/explorer/ComponentRegistry.cs
+++ b/src/explorer/ComponentRegistry.cs
@@ -1,9 +1,13 @@
 namespace Explorer.Components
 {
+    using System.Linq;
+    using BaselineTypeDiscovery;
     using Diffix;
     using Explorer.Common;
 
     using Lamar;
+    using Lamar.Scanning.Conventions;
+    using LamarCodeGeneration;
     using Microsoft.Extensions.DependencyInjection;
 
     public class ComponentRegistry : ServiceRegistry
@@ -15,19 +19,61 @@ namespace Explorer.Components
             {
                 _.Assembly("explorer");
                 _.IncludeNamespace("Explorer.Components");
-                _.AddAllTypesOf<PublisherComponent>(ServiceLifetime.Scoped);
                 _.ConnectImplementationsToTypesClosing(typeof(ResultProvider<>), ServiceLifetime.Scoped);
-                _.ConnectImplementationsToTypesClosing(typeof(ExplorerComponent<>), ServiceLifetime.Scoped);
-            });
 
-            // The following are not picked up by the scan for some reason, maybe because they close
-            // primitive types (?)
-            this.AddScoped<SimpleStats<double>>();
-            this.AddScoped<SimpleStats<long>>();
+                // Register the custom convention
+                _.Convention<PublisherScanner>();
+            });
 
             // Services to be injected at runtime
             Injectable<ExplorerContext>();
             Injectable<DConnection>();
+
+            // The following are not picked up by the scan for some reason, maybe because they close
+            // primitive types (?)
+            // RemoveAll(sd => sd.ImplementationType == typeof(SimpleStats<>));
+            For<ResultProvider<SimpleStats<double>.Result>>().Use<SimpleStats<double>>().Scoped();
+            For<ResultProvider<SimpleStats<long>.Result>>().Use<SimpleStats<long>>().Scoped();
+            For<ResultProvider<SimpleStats<int>.Result>>().Use<SimpleStats<int>>().Scoped();
+            For<ResultProvider<SimpleStats<decimal>.Result>>().Use<SimpleStats<decimal>>().Scoped();
+        }
+
+        /// <summary>
+        /// This custom convention registers PublisherComponents. If the PublisherComponent is already registered as
+        /// a ResultProvider, it forwards the invocation to the ResultProvider registration. This prevents duplicate
+        /// components from being instantiated.
+        /// </summary>
+        private class PublisherScanner : IRegistrationConvention
+        {
+            public void ScanTypes(TypeSet types, ServiceRegistry services)
+            {
+                var publisherComponentTypes = types
+                    .FindTypes(TypeClassification.Concretes | TypeClassification.Closed)
+                    .Where(t => t.GetInterfaces().Contains(typeof(PublisherComponent)));
+
+                // Register publisher components
+                foreach (var type in publisherComponentTypes)
+                {
+                    var resultProviderInterface = type.GetInterfaces().SingleOrDefault(IsResultProviderInterface);
+
+                    if (resultProviderInterface == default)
+                    {
+                        // Not yet registered
+                        services.AddScoped(typeof(PublisherComponent), type);
+                    }
+                    else
+                    {
+                        // Already registered as ResultProvider, forward the invocation
+                        services
+                            .For<PublisherComponent>()
+                            .Use(scope => (PublisherComponent)scope.GetService(resultProviderInterface))
+                            .Named(type.NameInCode());
+                    }
+                }
+            }
+
+            private bool IsResultProviderInterface(System.Type i)
+                => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ResultProvider<>);
         }
     }
 }

--- a/src/explorer/Components/CategoricalSampleGenerator.cs
+++ b/src/explorer/Components/CategoricalSampleGenerator.cs
@@ -6,7 +6,6 @@ namespace Explorer.Components
     using System.Text.Json;
     using System.Threading.Tasks;
 
-    using Diffix;
     using Explorer.Common;
     using Explorer.Metrics;
 
@@ -15,12 +14,11 @@ namespace Explorer.Components
     {
         public const int DefaultSamplesToPublish = 20;
 
-        private static readonly JsonElement JsonNullElement = JsonDocument.Parse("null").RootElement;
-        private readonly DistinctValuesComponent distinctValues;
+        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
 
-        public CategoricalSampleGenerator(DistinctValuesComponent distinctValues)
+        public CategoricalSampleGenerator(ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider)
         {
-            this.distinctValues = distinctValues;
+            this.distinctValuesProvider = distinctValuesProvider;
         }
 
         public int NumValuesToPublish { get; set; } = DefaultSamplesToPublish;
@@ -36,7 +34,7 @@ namespace Explorer.Components
 
         protected override async Task<Result> Explore()
         {
-            var distinctValuesResult = await distinctValues.ResultAsync;
+            var distinctValuesResult = await distinctValuesProvider.ResultAsync;
             var sampleValues = Enumerable.Empty<JsonElement>();
             if (distinctValuesResult.IsCategorical)
             {

--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -21,19 +21,19 @@ namespace Explorer.Components
 
         private readonly DConnection conn;
         private readonly ExplorerContext ctx;
-        private readonly EmailCheckComponent emailChecker;
-        private readonly DistinctValuesComponent distinctValues;
+        private readonly ResultProvider<EmailCheckComponent.Result> emailCheckProvider;
+        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
 
         public TextGeneratorComponent(
             DConnection conn,
             ExplorerContext ctx,
-            EmailCheckComponent emailChecker,
-            DistinctValuesComponent distinctValues)
+            ResultProvider<EmailCheckComponent.Result> emailCheckProvider,
+            ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider)
         {
             this.conn = conn;
             this.ctx = ctx;
-            this.emailChecker = emailChecker;
-            this.distinctValues = distinctValues;
+            this.emailCheckProvider = emailCheckProvider;
+            this.distinctValuesProvider = distinctValuesProvider;
             SamplesToPublish = DefaultSamplesToPublish;
             EmailDomainsCountThreshold = DefaultEmailDomainsCountThreshold;
             SubstringQueryColumnCount = DefaultSubstringQueryColumnCount;
@@ -47,21 +47,21 @@ namespace Explorer.Components
 
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()
         {
-            var distinctValuesResult = await distinctValues.ResultAsync;
+            var distinctValuesResult = await distinctValuesProvider.ResultAsync;
             if (!distinctValuesResult.IsCategorical)
             {
-            var result = await ResultAsync;
+                var result = await ResultAsync;
 
-            if (result.SampleValues.Count > 0)
-            {
-                yield return new UntypedMetric(name: "sample_values", metric: result.SampleValues);
+                if (result.SampleValues.Count > 0)
+                {
+                    yield return new UntypedMetric(name: "sample_values", metric: result.SampleValues);
+                }
             }
-        }
         }
 
         protected override async Task<Result> Explore()
         {
-                var emailCheckerResult = await emailChecker.ResultAsync;
+            var emailCheckerResult = await emailCheckProvider.ResultAsync;
             var sampleValues = emailCheckerResult.IsEmail ? await GenerateEmails() : await GenerateStrings();
             return new Result(sampleValues.ToList());
         }

--- a/src/explorer/LamarExtensions.cs
+++ b/src/explorer/LamarExtensions.cs
@@ -11,7 +11,7 @@ namespace Explorer.Components
             // Try to resolve using the PublisherComponent interface. If this doesn't work, auto-resolve
             // the concrete instance instead.
             var fromCollection = (T)scope.TryGetInstance<PublisherComponent>(typeof(T).NameInCode());
-          return fromCollection ?? scope.GetInstance<T>();
+            return fromCollection ?? scope.GetInstance<T>();
         }
     }
 }


### PR DESCRIPTION
Fixes #236 

There were actually two problems causing this:
1. Some `ExplorerComponent` implementations took other concrete implementations as constructor arguments. This caused the dependency injector to resolve these anew upon every invocation with a `transient` lifetime. We should always use interfaces (ie. `ResultProvider<T>`) in the constructor arguments for components to ensure the DI works as expected.
2. Wherever classes implemented two component interfaces, `ResultProvider<T>` and `PublisherComponent`, the DI treated these as separate invocations (despite the `scoped` lifetime) so there could be two (but no more 😅 ) of each of these components. Fixing this required some reflection magic during component registration to 'forward' the second registration to the first. 
