### PR TITLE
Take account of null and suppressed values in categorical sample generation.

### DIFF
--- a/src/diffix/Values/SuppressedValue.cs
+++ b/src/diffix/Values/SuppressedValue.cs
@@ -41,6 +41,6 @@ namespace Diffix.Values
         /// <remarks>
         /// Throws an exception, since accessing the value is an invalid operation.
         /// </remarks>
-        public T Value => throw new System.InvalidOperationException("Do not use NullValue.Value.");
+        public T Value => throw new System.InvalidOperationException("Do not use SuppressedValue.Value.");
     }
 }


### PR DESCRIPTION
When generating values for a categorical column, include `null` as a category, and exclude suppressed values.

Fixes #242