### PR TITLE
Remove trailing `+` from git commit hash.

### DIFF
--- a/src/explorer.api/Models/VersionInfo.cs
+++ b/src/explorer.api/Models/VersionInfo.cs
@@ -2,16 +2,15 @@ namespace Explorer.Api
 {
     internal sealed class VersionInfo
     {
-        public const string ThisCommitRef = ThisAssembly.Git.Branch;
+        private const string ThisCommitRef = ThisAssembly.Git.Branch;
+
+        private const string ThisCommitHash = ThisAssembly.Git.Sha;
 
         private VersionInfo(string commitHash, string commitRef)
         {
             CommitHash = commitHash;
             CommitRef = commitRef;
         }
-
-        public static string ThisCommitHash { get; } =
-            ThisAssembly.Git.Sha + (ThisAssembly.Git.IsDirty ? "+" : string.Empty);
 
         public string CommitRef { get; }
 


### PR DESCRIPTION
Removes the trailing `+` from the git commit hash since this doesn't work reliably in docker builds (see #207). 

Resolves #235 
