### PR TITLE
Fix Bug: range parameters in wrong order

### DIFF
--- a/src/explorer/Components/MinMaxRefiner.cs
+++ b/src/explorer/Components/MinMaxRefiner.cs
@@ -47,12 +47,13 @@ namespace Explorer.Components
         {
             // initial unconstrained min or max
             var result = await GetMinEstimate(null);
+            var isPositive = result >= 0;
 
             // limit the number of iterations
             for (var i = 0; i < MaxIterations; i++)
             {
                 // If we have a zero result, it can't be improved upon anyway.
-                if (result == decimal.Zero)
+                if (isPositive && result == decimal.Zero)
                 {
                     break;
                 }
@@ -62,7 +63,8 @@ namespace Explorer.Components
 
                 // If there are no longer enough values in the constrained range to compute an anonymised min/max,
                 // the query will return `null` => we can't improve further on the result.
-                // Same thing if the results start to diverge (second part of if condition).
+                // Same thing if the results start to diverge, ie. if the current result no longer improves on the
+                // previous result (second part of if condition).
                 if ((!estimate.HasValue) || (estimate >= result))
                 {
                     break;
@@ -79,10 +81,17 @@ namespace Explorer.Components
         {
             // initial unconstrained min or max
             var result = await GetMaxEstimate(null);
+            var isNegative = result < 0;
 
             // limit the number of iterations
             for (var i = 0; i < MaxIterations; i++)
             {
+                // If we are working with negative numbers and have a zero result, assume we can't improve it.
+                if (isNegative && result == decimal.Zero)
+                {
+                    break;
+                }
+
                 // Constrained query to get an improved estimate
                 var estimate = await GetMaxEstimate(result);
 

--- a/src/explorer/Queries/Max.cs
+++ b/src/explorer/Queries/Max.cs
@@ -38,9 +38,11 @@ namespace Explorer.Queries
 
         protected override string GetQueryStatement(string table, string column)
         {
-            var whereFragment = lowerBound.HasValue ?
-                $"where {column} between {lowerBound.Value} and {lowerBound.Value * 2}" :
-                string.Empty;
+            var whereFragment = lowerBound.HasValue
+                ? lowerBound >= 0
+                    ? $"where {column} between {lowerBound.Value} and {lowerBound.Value * 2}"
+                    : $"where {column} between {lowerBound.Value} and 0"
+                : string.Empty;
 
             return $@"
                 select

--- a/src/explorer/Queries/Min.cs
+++ b/src/explorer/Queries/Min.cs
@@ -38,9 +38,11 @@ namespace Explorer.Queries
 
         protected override string GetQueryStatement(string table, string column)
         {
-            var whereFragment = upperBound.HasValue ?
-                $"where {column} between 0 and {upperBound.Value}" :
-                string.Empty;
+            var whereFragment = upperBound.HasValue
+                ? upperBound >= 0
+                    ? $"where {column} between 0 and {upperBound.Value}"
+                    : $"where {column} between {upperBound.Value * 2} and {upperBound.Value}"
+                : string.Empty;
 
             return $@"
                 select

--- a/tests/explorer.tests/ComponentTests.cs
+++ b/tests/explorer.tests/ComponentTests.cs
@@ -41,6 +41,26 @@ namespace Explorer.Tests
         }
 
         [Fact]
+        public async Task TestMinMaxRefinerComponentWithNegativeValues()
+        {
+            using var scope = await testFixture.CreateTestScope("taxi", "jan08", "pickup_longitude", this);
+
+            // Construct MinMaxRefiner explicitly in order to inject a null result from MinMaxFromHistogramComponent
+            var histogramMinMaxProvider = new StaticResultProvider<MinMaxFromHistogramComponent.Result>(null!);
+            var refiner = new MinMaxRefiner(histogramMinMaxProvider) { Context = scope.Context };
+
+            TestResult(await refiner.ResultAsync);
+
+            static void TestResult(MinMaxRefiner.Result result)
+            {
+                const decimal aircloakMin = -106M;
+                const decimal aircloakMax = -6M;
+                Assert.True(result.Min < aircloakMin, $"Expected lower than {aircloakMin}, got {result.Min}");
+                Assert.True(result.Max > aircloakMax, $"Expected higher than {aircloakMax}, got {result.Max}");
+            }
+        }
+
+        [Fact]
         public async Task TestDistinctValuesMetricContainsRemainder()
         {
             using var scope = await testFixture.CreateTestScope("gda_banking", "loans", "duration", this);


### PR DESCRIPTION
Fixes #255

When running the MinMaxRefiner on negative values, the range constraints for the min and max queries were in the wrong order. Fixed by adding a check: if the values are negative, use different range constraints. 

edit: also fixes #91 