### PR TITLE
Bug squashing

### DIFF
--- a/src/explorer/Common/RandomExtensions.cs
+++ b/src/explorer/Common/RandomExtensions.cs
@@ -15,7 +15,7 @@ namespace Explorer.Common
         {
             if (max <= min)
             {
-                throw new ArgumentOutOfRangeException(nameof(max), "max must be > min!");
+                throw new ArgumentOutOfRangeException(nameof(max), $"max must be > min! Got max {max} and min {min}");
             }
 
             // Working with ulong so that modulo works correctly with values > long.MaxValue

--- a/src/explorer/Common/SubstringsData.cs
+++ b/src/explorer/Common/SubstringsData.cs
@@ -29,7 +29,7 @@ namespace Explorer.Common
             Substrings[pos].AddValueCount(s, count);
         }
 
-        public string GetRandomSubstring(int pos, Random rand)
+        public string? GetRandomSubstring(int pos, Random rand)
         {
             return Substrings[pos].GetRandomValue(rand);
         }

--- a/src/explorer/Common/ValueWithCountList.cs
+++ b/src/explorer/Common/ValueWithCountList.cs
@@ -2,6 +2,7 @@ namespace Explorer.Common
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
 
     internal class ValueWithCountList<T> : List<(T Value, long Count)>
     {
@@ -22,8 +23,14 @@ namespace Explorer.Common
             Add((value, TotalCount + count));
         }
 
+        [return: MaybeNull]
         public T GetRandomValue(Random rand)
         {
+            if (TotalCount == 0)
+            {
+                return default;
+            }
+
             var rcount = rand.NextLong(TotalCount);
             return FindValue(rcount);
         }

--- a/src/explorer/Components/Datetime/CyclicalTimeBuckets.cs
+++ b/src/explorer/Components/Datetime/CyclicalTimeBuckets.cs
@@ -31,7 +31,7 @@ namespace Explorer.Components
         {
             var queryResult = await Context.Exec(new CyclicalDatetimes(Context.ColumnInfo.Type));
 
-            var groupings = await Task.Run(() => ProcessCyclicalBuckets(queryResult.Rows));
+            var groupings = ProcessCyclicalBuckets(queryResult.Rows).ToList();
 
             return new Result(
                 groupings.Select(g => g.Item1),

--- a/src/explorer/Components/Datetime/DatetimeDistributionComponent.cs
+++ b/src/explorer/Components/Datetime/DatetimeDistributionComponent.cs
@@ -17,8 +17,13 @@ namespace Explorer.Components
             this.timeBucketsResultProvider = timeBucketsResultProvider;
         }
 
-        public static DatetimeDistribution GenerateDistribution(LinearTimeBuckets.Result timeBuckets)
+        public static DatetimeDistribution? GenerateDistribution(LinearTimeBuckets.Result timeBuckets)
         {
+            if (!timeBuckets.Rows.Any())
+            {
+                return null;
+            }
+
             var (bucketGroup, valueCounts) = timeBuckets.Rows.Zip(timeBuckets.ValueCounts).Last();
             var timeUnit = bucketGroup.Key;
 

--- a/src/explorer/Components/Datetime/LinearTimeBuckets.cs
+++ b/src/explorer/Components/Datetime/LinearTimeBuckets.cs
@@ -5,7 +5,6 @@ namespace Explorer.Components
     using System.Linq;
     using System.Threading.Tasks;
 
-    using Diffix;
     using Explorer.Common;
     using Explorer.Metrics;
     using Explorer.Queries;
@@ -32,7 +31,7 @@ namespace Explorer.Components
         {
             var queryResult = await Context.Exec(new BucketedDatetimes(Context.ColumnInfo.Type));
 
-            var groupings = await Task.Run(() => ProcessLinearBuckets(queryResult.Rows));
+            var groupings = ProcessLinearBuckets(queryResult.Rows).ToList();
 
             return new Result(
                 groupings.Select(g => g.Item1),

--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -76,7 +76,7 @@ namespace Explorer.Components
             var len = rand.Next(minLength, minLength + substrings.Count);
             for (var pos = 0; pos < substrings.Count && sb.Length < len; pos++)
             {
-                var str = substrings.GetRandomSubstring(pos, rand);
+                var str = substrings.GetRandomSubstring(pos, rand) ?? "*";
                 sb.Append(str);
                 pos += str.Length;
             }

--- a/src/explorer/Metrics/ExploreMetric.cs
+++ b/src/explorer/Metrics/ExploreMetric.cs
@@ -6,6 +6,7 @@ namespace Explorer.Metrics
     {
         public string Name { get; }
 
+        [JsonPropertyName("value")]
         public object Metric { get; }
 
         [JsonIgnore]


### PR DESCRIPTION
- Rename "metrics" to "values" in json payload. 
- Handle suppressed substrings by returning a nullable string from the random string extractor, and use `*` as a placeholder in the generated string. 
- Prevent exception thrown on null dereference when datetime histogram is not generated. This just prevents the crash but doesn't fix the underlying problem. (see #267)

Fixes #265 
Fixes #266 

