### PR TITLE
More bug squashing 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
 		// "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
 		// "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
 		// A development api key can be imported from the local environment
-		"Explorer__AircloakApiKey": "${localEnv:AIRCLOAK_API_KEY}"
+		"Explorer__AircloakApiKey": "${localEnv:AIRCLOAK_API_KEY}",
+		"Sentry__ServerName": "${localEnv:USER}-${containerEnv:HOSTNAME}"
 	},
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [

--- a/src/explorer/Components/Datetime/DatetimeDistributionComponent.cs
+++ b/src/explorer/Components/Datetime/DatetimeDistributionComponent.cs
@@ -19,7 +19,7 @@ namespace Explorer.Components
 
         public static DatetimeDistribution? GenerateDistribution(LinearTimeBuckets.Result timeBuckets)
         {
-            if (!timeBuckets.Rows.Any())
+            if (!timeBuckets.ValueCounts.Any(vc => vc.NonSuppressedNonNullCount > 0))
             {
                 return null;
             }

--- a/src/explorer/Components/Datetime/DatetimeGeneratorComponent.cs
+++ b/src/explorer/Components/Datetime/DatetimeGeneratorComponent.cs
@@ -32,7 +32,7 @@ namespace Explorer.Components
                 metric: distribution
                         .Generate(SamplesToPublish)
                         .OrderBy(_ => _)
-                        .ToArray());
+                        .ToList());
         }
     }
 }

--- a/src/explorer/Components/Datetime/TimeUtilities.cs
+++ b/src/explorer/Components/Datetime/TimeUtilities.cs
@@ -37,16 +37,16 @@ namespace Explorer.Components
             {
                 Total = total,
                 Suppressed = suppressed,
-                Counts =
-                    from row in valueCounts
-                    where row.HasValue
-                    orderby row.GroupingIndex ascending
-                    select new
+                Counts = valueCounts
+                    .Where(row => row.HasValue)
+                    .OrderBy(row => row.GroupingIndex)
+                    .Select(row => new
                     {
                         row.Value,
                         row.Count,
                         row.CountNoise,
-                    },
+                    })
+                    .ToList(),
             };
         }
 

--- a/src/explorer/Components/DistinctValuesComponent.cs
+++ b/src/explorer/Components/DistinctValuesComponent.cs
@@ -87,12 +87,12 @@ namespace Explorer.Components
         {
             public Result(IEnumerable<ValueWithCount<JsonElement>> distinctRows)
             {
-                DistinctRows = distinctRows;
+                DistinctRows = distinctRows.ToList();
                 ValueCounts = ValueCounts.Compute(distinctRows);
                 IsCategorical = ValueCounts.SuppressedRowRatio < SuppressedRatioThreshold;
             }
 
-            public IEnumerable<ValueWithCount<JsonElement>> DistinctRows { get; }
+            public List<ValueWithCount<JsonElement>> DistinctRows { get; }
 
             public ValueCounts ValueCounts { get; }
 

--- a/src/explorer/Components/DistributionAnalysisComponent.cs
+++ b/src/explorer/Components/DistributionAnalysisComponent.cs
@@ -57,7 +57,8 @@ namespace Explorer.Components
                         }
                         .Where(gm => !(gm is null) && double.IsFinite(gm.PValue)),
                     };
-                }));
+                })
+                .ToList());
         }
 
         protected override async Task<GoodnessOfFitCollection?> Explore()

--- a/src/explorer/Components/DistributionPublishers/NumericSampleGenerator.cs
+++ b/src/explorer/Components/DistributionPublishers/NumericSampleGenerator.cs
@@ -47,7 +47,7 @@ namespace Explorer.Components
                         .Generate(SamplesToPublish)
                         .Select(s => Context.ColumnInfo.Type == Diffix.DValueType.Real ? s : Convert.ToInt64(s))
                         .OrderBy(_ => _)
-                        .ToArray());
+                        .ToList());
         }
     }
 }

--- a/src/explorer/Components/HistogramSelectorComponent.cs
+++ b/src/explorer/Components/HistogramSelectorComponent.cs
@@ -35,7 +35,8 @@ namespace Explorer.Components
                 b.LowerBound,
                 b.Count,
                 b.CountNoise,
-            }));
+            })
+            .ToList());
             yield return new UntypedMetric("histogram.suppressed_count", result.ValueCounts.SuppressedCount);
             yield return new UntypedMetric("histogram.suppressed_ratio", result.ValueCounts.SuppressedCountRatio);
             yield return new UntypedMetric("histogram.value_counts", result.ValueCounts);

--- a/src/explorer/Components/NumericDistributionComponent.cs
+++ b/src/explorer/Components/NumericDistributionComponent.cs
@@ -5,7 +5,6 @@
     using System.Threading.Tasks;
 
     using Accord.Statistics.Distributions.Univariate;
-    using Explorer.Common;
     using Explorer.Components.ResultTypes;
 
     public class NumericDistributionComponent : ExplorerComponent<NumericDistribution>
@@ -17,9 +16,14 @@
             this.histogramResultProvider = histogramResultProvider;
         }
 
-        public static NumericDistribution GenerateDistribution(Histogram histogram)
+        public static NumericDistribution? GenerateDistribution(HistogramWithCounts histogramResult)
         {
-            var samples = histogram.Buckets.Values.Select(bucket =>
+            if (histogramResult.ValueCounts.NonSuppressedNonNullCount == 0)
+            {
+                return null;
+            }
+
+            var samples = histogramResult.Histogram.Buckets.Values.Select(bucket =>
             {
                 var sampleValue = bucket.LowerBound + (bucket.BucketSize.SnappedSize / 2);
                 var sampleWeight = Convert.ToInt32(bucket.Count);
@@ -46,7 +50,7 @@
                 return null;
             }
 
-            return GenerateDistribution(histogramResult.Histogram);
+            return GenerateDistribution(histogramResult);
         }
     }
 }

--- a/src/explorer/Components/TextLengthComponent.cs
+++ b/src/explorer/Components/TextLengthComponent.cs
@@ -26,7 +26,8 @@ namespace Explorer.Components
                 result.DistinctRows
                     .Where(r => r.HasValue)
                     .OrderBy(r => r.Value.GetInt32())
-                    .Select(r => new { r.Value, r.Count }));
+                    .Select(r => new { r.Value, r.Count })
+                    .ToList());
             yield return new UntypedMetric("text.length.counts", result.ValueCounts);
         }
 

--- a/src/explorer/Queries/DistinctLengths.cs
+++ b/src/explorer/Queries/DistinctLengths.cs
@@ -19,7 +19,7 @@ namespace Explorer.Queries
                     count(*),
                     count_noise(*)
                 from {table}
-                group by {column}";
+                group by 1";
         }
     }
 }


### PR DESCRIPTION
4 commits here:

- [FIX] Don't attempt to generate a value distribution if the column contains only `null` values. 
- [FIX] Evaluate list of metrics strictly instead of lazily. I think a side-effect of this was that exceptions were being thrown in the wrong place and not being caught / forwarded to sentry / included in the `errors` returned via the api.
- [FIX] Group string lengths correctly to prevent duplicates. 
- [DEV] Add sentry server name in devcontainer. 

Fixes #282 
