### PR TITLE
Improve container lifetime mangement in `Exploration`.

### DIFF
--- a/src/explorer.api/Controllers/ExploreController.cs
+++ b/src/explorer.api/Controllers/ExploreController.cs
@@ -8,6 +8,7 @@ namespace Explorer.Api.Controllers
     using Explorer;
     using Explorer.Api.Authentication;
     using Explorer.Api.Models;
+    using Lamar;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
@@ -35,7 +36,8 @@ namespace Explorer.Api.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public IActionResult Explore(
-            [FromServices] Exploration exploration,
+            [FromServices] IContainer rootContainer,
+            [FromServices] ExplorationScopeBuilder scopeBuilder,
             [FromServices] JsonApiContextBuilder contextBuilder,
             [FromServices] IAircloakAuthenticationProvider authProvider,
             ExploreParams data)
@@ -47,6 +49,7 @@ namespace Explorer.Api.Controllers
             }
 
             // Launch and register the exploration.
+            var exploration = new Exploration(rootContainer, scopeBuilder);
             exploration.Initialise(contextBuilder, data);
             exploration.Run();
 

--- a/src/explorer/AbstractExploration.cs
+++ b/src/explorer/AbstractExploration.cs
@@ -1,9 +1,7 @@
 ﻿namespace Explorer
 {
-    using System.Collections.Generic;
+    using System;
     using System.Threading.Tasks;
-
-    using Explorer.Metrics;
 
     using static ExplorationStatusEnum;
 
@@ -34,5 +32,19 @@
         }
 
         protected abstract Task RunTask();
+
+        protected async Task RunStage(ExplorationStatus initialStatus, Func<Task> t)
+        {
+            Status = initialStatus;
+            try
+            {
+                await t();
+            }
+            catch
+            {
+                Status = ExplorationStatus.Error;
+                throw;
+            }
+        }
     }
 }

--- a/src/explorer/Exploration.cs
+++ b/src/explorer/Exploration.cs
@@ -12,7 +12,7 @@ namespace Explorer
 
     public sealed class Exploration : AbstractExploration, IDisposable
     {
-        private readonly IContainer rootContainer;
+        private readonly IContainer explorationRootContainer;
         private readonly ExplorationScopeBuilder scopeBuilder;
         private readonly CancellationTokenSource cancellationTokenSource;
         private bool disposedValue;
@@ -21,7 +21,7 @@ namespace Explorer
             IContainer rootContainer,
             ExplorationScopeBuilder scopeBuilder)
         {
-            this.rootContainer = rootContainer;
+            explorationRootContainer = (IContainer)rootContainer.GetNestedContainer();
             this.scopeBuilder = scopeBuilder;
             cancellationTokenSource = new CancellationTokenSource();
         }
@@ -82,7 +82,7 @@ namespace Explorer
                     ColumnExplorations = contexts
                         .Select(context =>
                         {
-                            var scope = scopeBuilder.Build(rootContainer.GetNestedContainer(), context);
+                            var scope = scopeBuilder.Build(explorationRootContainer.GetNestedContainer(), context);
                             return new ColumnExploration(scope);
                         })
                         .ToImmutableArray();
@@ -96,20 +96,17 @@ namespace Explorer
             // Multi-column analyses
             // We have access to all the ColumnExplorations here, so we should be able to extract some
             // context around which column combinations are promising candidates for multi-column analysis.
-        }
+            // await RunStage(
+            //     ExplorationStatus.Processing,
+            //     async () =>
+            //     {
+            //         var multiColumnExploration = new MultiColumnExploration(ColumnExplorations);
+            //
+            //         await multiColumnExploration.Completion;
+            //     });
 
-        private async Task RunStage(ExplorationStatus initialStatus, Func<Task> t)
-        {
-            Status = initialStatus;
-            try
-            {
-                await t();
-            }
-            catch
-            {
-                Status = ExplorationStatus.Error;
-                throw;
-            }
+            // Completed successfully
+            Status = ExplorationStatus.Complete;
         }
 
         private void Dispose(bool disposing)
@@ -122,6 +119,7 @@ namespace Explorer
                     {
                         item.Dispose();
                     }
+                    explorationRootContainer.Dispose();
                     cancellationTokenSource.Dispose();
                 }
                 disposedValue = true;


### PR DESCRIPTION
Exploration new creates a NestedContainer and manages the lifetime thereof, rather than expecting
the lifetime to be managed by Lamar.

Replaces #313 
Fixes #309 