### PR TITLE
Daniel/multi column fixes

### DIFF
--- a/src/explorer/Common/GroupingIdConverter.cs
+++ b/src/explorer/Common/GroupingIdConverter.cs
@@ -19,6 +19,12 @@
     /// </remarks>
     internal sealed class GroupingIdConverter
     {
+        /// <summary>
+        /// This is the maximum number of columns that can be included in a grouping statement. For most DBs this is
+        /// 32 (the number of bits in an int).
+        /// </summary>
+        public const int GroupSizeLimit = 32;
+
         private static ImmutableDictionary<int, GroupingIdConverter> converters =
             ImmutableDictionary.Create<int, GroupingIdConverter>();
 
@@ -28,9 +34,9 @@
 
         private GroupingIdConverter(int groupSizeMax)
         {
-            if (groupSizeMax < 1 || groupSizeMax >= sizeof(int) * 8)
+            if (groupSizeMax < 1 || groupSizeMax >= GroupSizeLimit)
             {
-                throw new ArgumentOutOfRangeException($"Group size must be in range [1 {sizeof(int) * 8}].");
+                throw new ArgumentOutOfRangeException($"Group size must be in range [1 {GroupSizeLimit}].");
             }
 
             var mask = 0;

--- a/src/explorer/Common/Utilities.cs
+++ b/src/explorer/Common/Utilities.cs
@@ -1,5 +1,6 @@
 namespace Explorer.Common
 {
+    using System.Text.Json;
     using System.Threading.Tasks;
 
     public static class Utilities
@@ -9,6 +10,12 @@ namespace Explorer.Common
             await Task.WhenAll(task1, task2, task3);
 
             return (task1.Result, task2.Result, task3.Result);
+        }
+
+        internal static JsonElement MakeJsonNull()
+        {
+            using var jdoc = JsonDocument.Parse("null");
+            return jdoc.RootElement.Clone();
         }
     }
 }

--- a/src/explorer/Components/CategoricalSampleGenerator.cs
+++ b/src/explorer/Components/CategoricalSampleGenerator.cs
@@ -12,7 +12,7 @@ namespace Explorer.Components
     public class CategoricalSampleGenerator
         : ExplorerComponent<CategoricalSampleGenerator.Result>, PublisherComponent
     {
-        private static readonly JsonElement JsonNull = JsonDocument.Parse("null").RootElement;
+        private static readonly JsonElement JsonNull = Utilities.MakeJsonNull();
 
         private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
         private readonly ResultProvider<SampleValuesGeneratorConfig.Result> sampleValuesGeneratorConfigProvider;

--- a/src/explorer/Components/ColumnCorrelationComponent.cs
+++ b/src/explorer/Components/ColumnCorrelationComponent.cs
@@ -215,10 +215,7 @@
                     }
                 }
 
-                if (queryResults?.Any() ?? false)
-                {
-                    throw;
-                }
+                throw;
             }
 
             var groups = queryResults.GroupBy(row => row.ColumnGrouping);

--- a/src/explorer/Components/ColumnCorrelationComponent.cs
+++ b/src/explorer/Components/ColumnCorrelationComponent.cs
@@ -195,6 +195,11 @@
                 return null;
             }
 
+            // Aircloak back-end queries add an extra member to the grouping query, so we can group at most
+            // (GroupSizeLimit - 1) columns.
+            // TODO: Find a way to include all columns and recombine the results instead of truncating the list.
+            Projections = Projections.Take(GroupingIdConverter.GroupSizeLimit - 1).ToImmutableArray();
+
             IEnumerable<MultiColumnCounts.Result>? queryResults = default;
             try
             {

--- a/src/explorer/Components/DistinctValuesComponent.cs
+++ b/src/explorer/Components/DistinctValuesComponent.cs
@@ -15,6 +15,8 @@ namespace Explorer.Components
     public class DistinctValuesComponent
         : ExplorerComponent<DistinctValuesComponent.Result>, PublisherComponent
     {
+        private static readonly JsonElement JsonNull = Utilities.MakeJsonNull();
+
         private readonly ExplorerOptions options;
 
         public DistinctValuesComponent(IOptions<ExplorerOptions> options)
@@ -36,11 +38,11 @@ namespace Explorer.Components
                 // considered categorical or quasi-categorical.
                 var distinctValues =
                     from row in result.DistinctRows
-                    where row.HasValue
+                    where !row.IsSuppressed
                     orderby row.Count descending
                     select new
                     {
-                        row.Value,
+                        Value = row.IsNull ? JsonNull : row.Value,
                         row.Count,
                     };
 

--- a/src/explorer/Components/EmailCheckComponent.cs
+++ b/src/explorer/Components/EmailCheckComponent.cs
@@ -38,7 +38,7 @@ namespace Explorer.Components
 
             var emailCheck = await Context.Exec(new EmailCheck());
             var emailCount = emailCheck.Rows.First();
-            var isEmail = emailCount >= distinctValuesResult.ValueCounts.NonSuppressedNonNullCount;
+            var isEmail = emailCount > 0L && emailCount >= distinctValuesResult.ValueCounts.NonSuppressedNonNullCount;
             return new Result(isEmail);
         }
 


### PR DESCRIPTION
Fixes a few minor issues. 

- `IsEmail` could return `true` when there were no non-null values in a column. 
- `null` values were implicitly included in the counts for distinct values, but not in the list of distinct values returned in the column metrics. 
- Errors on grouping sub-queries didn't always cause the exploration to fail, this has been changed. Better to throw and make the failure explicit (and report to api consumer) than to fail silently and return computations based on incomplete data.

And one not-so-minor issue:
- If more than 31 columns were requested can't group over the whole table (#342).

Solution:
  - Remove any invariant columns to reduce the total column count. 
  - Only consider the first 31 columns for correlation analysis- any further columns will be sampled as independent variables. 

This has the downside that if there are more than 31 useful columns in a table, they will not be considered for correlation analysis. Hopefully this is rare enough as not to be a major issue. An exhaustive fix for this issue involves breaking the correlation analysis queries up into sub-queries so that each sub-query has no more than 31 columns, and then recombining the results for the correlation analysis (probability matrices). I'll create an issue for this for future reference.

Fixes #342 
Fixes #346 