### PR TITLE
Consider distinct values for min/max estimation.

### DIFF
--- a/src/explorer/Components/ColumnCorrelationComponent.cs
+++ b/src/explorer/Components/ColumnCorrelationComponent.cs
@@ -23,7 +23,7 @@
 
         public ColumnCorrelationComponent(
             IOptions<ExplorerOptions> options,
-            Logger<ColumnCorrelationComponent> logger)
+            ILogger<ColumnCorrelationComponent> logger)
         {
             Logger = logger;
             this.options = options.Value;
@@ -31,7 +31,7 @@
 
         public ImmutableArray<ColumnProjection> Projections { get; set; } = ImmutableArray<ColumnProjection>.Empty;
 
-        private Logger<ColumnCorrelationComponent> Logger { get; }
+        private ILogger<ColumnCorrelationComponent> Logger { get; }
 
         private int MaxCorrelationDepth => options.MaxCorrelationDepth;
 

--- a/src/explorer/Components/ColumnCorrelationComponent.cs
+++ b/src/explorer/Components/ColumnCorrelationComponent.cs
@@ -21,12 +21,17 @@
     {
         private readonly ExplorerOptions options;
 
-        public ColumnCorrelationComponent(IOptions<ExplorerOptions> options)
+        public ColumnCorrelationComponent(
+            IOptions<ExplorerOptions> options,
+            Logger<ColumnCorrelationComponent> logger)
         {
+            Logger = logger;
             this.options = options.Value;
         }
 
         public ImmutableArray<ColumnProjection> Projections { get; set; } = ImmutableArray<ColumnProjection>.Empty;
+
+        private Logger<ColumnCorrelationComponent> Logger { get; }
 
         private int MaxCorrelationDepth => options.MaxCorrelationDepth;
 
@@ -211,7 +216,7 @@
                 {
                     foreach (var innerEx in agg.Flatten().InnerExceptions)
                     {
-                        Logger?.LogWarning(innerEx, "Drill-down query error.");
+                        Logger.LogWarning(innerEx, "Drill-down query error.");
                     }
                 }
 

--- a/src/explorer/Components/DistinctValuesComponent.cs
+++ b/src/explorer/Components/DistinctValuesComponent.cs
@@ -28,44 +28,37 @@ namespace Explorer.Components
 
         public IEnumerable<ExploreMetric> YieldMetrics(Result result)
         {
-            if (!result.ValueCounts.IsCategorical)
-            {
-                yield return new UntypedMetric(name: "distinct.is_categorical", metric: false);
-            }
-            else
-            {
-                // Only few of the values are suppressed. This means the data is already well-segmented and can be
-                // considered categorical or quasi-categorical.
-                var distinctValues =
-                    from row in result.DistinctRows
-                    where !row.IsSuppressed
-                    orderby row.Count descending
-                    select new
-                    {
-                        Value = row.IsNull ? JsonNull : row.Value,
-                        row.Count,
-                    };
-
-                var toPublish = distinctValues.Take(NumValuesToPublish);
-                var remaining = distinctValues.Skip(NumValuesToPublish);
-
-                if (remaining.Any())
+            // Only few of the values are suppressed. This means the data is already well-segmented and can be
+            // considered categorical or quasi-categorical.
+            var distinctValues =
+                from row in result.DistinctRows
+                where !row.IsSuppressed
+                orderby row.Count descending
+                select new
                 {
-                    using var jdoc = JsonDocument.Parse("\"--OTHER--\"");
-                    toPublish = toPublish.Append(new
-                    {
-                        Value = jdoc.RootElement.Clone(),
-                        Count = remaining.Sum(distinct => distinct.Count),
-                    });
-                }
+                    Value = row.IsNull ? JsonNull : row.Value,
+                    row.Count,
+                };
 
-                var valueCounts = result.ValueCounts;
-                yield return new UntypedMetric(name: "distinct.is_categorical", metric: true);
-                yield return new UntypedMetric(name: "distinct.values", metric: toPublish.ToList());
-                yield return new UntypedMetric(name: "distinct.null_count", metric: valueCounts.NullCount);
-                yield return new UntypedMetric(name: "distinct.suppressed_count", metric: valueCounts.SuppressedCount);
-                yield return new UntypedMetric(name: "distinct.value_count", metric: valueCounts.TotalCount);
+            var toPublish = distinctValues.Take(NumValuesToPublish);
+            var remaining = distinctValues.Skip(NumValuesToPublish);
+
+            if (remaining.Any())
+            {
+                using var jdoc = JsonDocument.Parse("\"--OTHER--\"");
+                toPublish = toPublish.Append(new
+                {
+                    Value = jdoc.RootElement.Clone(),
+                    Count = remaining.Sum(distinct => distinct.Count),
+                });
             }
+
+            var valueCounts = result.ValueCounts;
+            yield return new UntypedMetric(name: "distinct.is_categorical", metric: result.ValueCounts.IsCategorical);
+            yield return new UntypedMetric(name: "distinct.values", metric: toPublish.ToList());
+            yield return new UntypedMetric(name: "distinct.null_count", metric: valueCounts.NullCount);
+            yield return new UntypedMetric(name: "distinct.suppressed_count", metric: valueCounts.SuppressedCount);
+            yield return new UntypedMetric(name: "distinct.value_count", metric: valueCounts.TotalCount);
         }
 
         public async IAsyncEnumerable<ExploreMetric> YieldMetrics()

--- a/src/explorer/Components/ExplorerComponentBase.cs
+++ b/src/explorer/Components/ExplorerComponentBase.cs
@@ -1,15 +1,10 @@
 namespace Explorer.Components
 {
-    using Microsoft.Extensions.Logging;
-
     public abstract class ExplorerComponentBase
     {
 #pragma warning disable CS8618 // Non-nullable property 'Context' is uninitialized. (property is set using Lamar DI)
         [Lamar.SetterProperty]
         public ExplorerContext Context { get; set; }
-
-        [Lamar.SetterProperty]
-        public ILogger Logger { get; set; }
 #pragma warning restore CS8618
     }
 }

--- a/src/explorer/Components/MinMaxRefiner.cs
+++ b/src/explorer/Components/MinMaxRefiner.cs
@@ -44,7 +44,7 @@ namespace Explorer.Components
             {
                 return null;
             }
-            if (stats.Min == null || stats.Max == null)
+            if (stats.Min == null || stats.Max == null || stats.Min == stats.Max)
             {
                 return null;
             }

--- a/src/explorer/Components/NumericHistogramComponent.cs
+++ b/src/explorer/Components/NumericHistogramComponent.cs
@@ -21,14 +21,14 @@ namespace Explorer.Components
         public NumericHistogramComponent(
             ResultProvider<SimpleStats<double>.Result> statsResultProvider,
             ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
-            Logger<NumericHistogramComponent> logger)
+            ILogger<NumericHistogramComponent> logger)
         {
             this.statsResultProvider = statsResultProvider;
             this.distinctValuesProvider = distinctValuesProvider;
             Logger = logger;
         }
 
-        private Logger<NumericHistogramComponent> Logger { get; }
+        private ILogger<NumericHistogramComponent> Logger { get; }
 
         protected async override Task<List<HistogramWithCounts>?> Explore()
         {

--- a/src/explorer/Components/NumericHistogramComponent.cs
+++ b/src/explorer/Components/NumericHistogramComponent.cs
@@ -8,6 +8,7 @@ namespace Explorer.Components
     using Explorer.Common;
     using Explorer.Components.ResultTypes;
     using Explorer.Queries;
+    using Microsoft.Extensions.Logging;
 
     public class NumericHistogramComponent :
         ExplorerComponent<List<HistogramWithCounts>>
@@ -15,11 +16,19 @@ namespace Explorer.Components
         private const long ValuesPerBucketTarget = 20;
 
         private readonly ResultProvider<SimpleStats<double>.Result> statsResultProvider;
+        private readonly ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider;
 
-        public NumericHistogramComponent(ResultProvider<SimpleStats<double>.Result> statsResultProvider)
+        public NumericHistogramComponent(
+            ResultProvider<SimpleStats<double>.Result> statsResultProvider,
+            ResultProvider<DistinctValuesComponent.Result> distinctValuesProvider,
+            Logger<NumericHistogramComponent> logger)
         {
             this.statsResultProvider = statsResultProvider;
+            this.distinctValuesProvider = distinctValuesProvider;
+            Logger = logger;
         }
+
+        private Logger<NumericHistogramComponent> Logger { get; }
 
         protected async override Task<List<HistogramWithCounts>?> Explore()
         {
@@ -28,15 +37,32 @@ namespace Explorer.Components
             {
                 return null;
             }
-            if (stats.Min == null || stats.Max == null)
+
+            var (minBound, maxBound) = (stats.Min, stats.Max);
+            if (!minBound.HasValue || !maxBound.HasValue)
             {
+                var distincts = await distinctValuesProvider.ResultAsync;
+                if (distincts == null || distincts.ValueCounts.NonSuppressedNonNullCount == 0)
+                {
+                    return null;
+                }
+
+                var values = distincts.DistinctRows.Where(row => row.HasValue).Select(row => row.Value.GetDouble());
+                minBound ??= values.Min();
+                maxBound ??= values.Max();
+            }
+
+            if (!minBound.HasValue || !maxBound.HasValue || minBound == maxBound)
+            {
+                Logger.LogWarning("Unable to calculate suitable bounds for numerical column {Context.Column}.");
+
                 return null;
             }
 
             var bucketsToSample = BucketUtils.EstimateBucketResolutions(
                 stats.Count,
-                stats.Min.Value,
-                stats.Max.Value,
+                (double)minBound,
+                (double)maxBound,
                 ValuesPerBucketTarget,
                 isIntegerColumn: Context.ColumnInfo.Type == DValueType.Integer);
 

--- a/src/explorer/Queries/MultiColumn/MultiColumnScopeBuilder.cs
+++ b/src/explorer/Queries/MultiColumn/MultiColumnScopeBuilder.cs
@@ -140,7 +140,7 @@
                 catch (InvalidOperationException)
                 {
                     throw new InvalidOperationException(
-                        $"Expected <{metricName}> metric of type {typeof(T)} for column '{Column}' but none was found.");
+                        $"Expected '{metricName}' metric of type '{typeof(T)}' for column '{Column}' but none was found.");
                 }
             }
         }

--- a/src/explorer/Queries/MultiColumn/MultiColumnScopeBuilder.cs
+++ b/src/explorer/Queries/MultiColumn/MultiColumnScopeBuilder.cs
@@ -140,7 +140,7 @@
                 catch (InvalidOperationException)
                 {
                     throw new InvalidOperationException(
-                        $"Expected <{metricName}> metric of type {typeof(T)} column {Column} but none was found.");
+                        $"Expected <{metricName}> metric of type {typeof(T)} for column '{Column}' but none was found.");
                 }
             }
         }

--- a/tests/explorer.tests/Setup/ExplorerTestFixture.cs
+++ b/tests/explorer.tests/Setup/ExplorerTestFixture.cs
@@ -39,6 +39,9 @@ namespace Explorer.Tests
                 registry.Configure<ConnectionOptions>(Config);
                 registry.Configure<VcrOptions>(Config);
 
+                // Logging
+                registry.AddLogging();
+
                 // VCR setup
                 registry.Injectable<Cassette>();
                 registry.For<IHttpClientFactory>().Use<VcrApiHttpClientFactory>();


### PR DESCRIPTION
In some cases min and max values aren't returned from the min and max sql
functions (returns null instead). This change adds a check for this and
uses the distinct values as backup to try to estimate a min and max.

This change also adds the distinct values metric to all result sets,
irrespective of whether the column is considered categorical or not.

I also replaced the generic `ILogger` with explicit `ILogger<T>` for
`ExploreComponent`s since the ILogger was not being correcly
injected by Lamar.

Fixes #354 
Fixes #355 