### PR TITLE
Include datetime columns in correlation analysis.

### DIFF
--- a/src/explorer/Queries/ColumnProjections/DatetimeProjection.cs
+++ b/src/explorer/Queries/ColumnProjections/DatetimeProjection.cs
@@ -1,0 +1,45 @@
+namespace Explorer.Queries
+{
+    using System;
+    using System.Text.Json;
+
+    public class DatetimeProjection : ColumnProjection
+    {
+        private readonly string dateInterval;
+        private readonly Random rng = new Random();
+
+        public DatetimeProjection(string column, int index, string dateInterval)
+        : base(column, index)
+        {
+            this.dateInterval = dateInterval;
+        }
+
+        public override string Project()
+        {
+            return $"date_trunc('{dateInterval}', {Column})";
+        }
+
+        public override object? Invert(JsonElement value)
+        {
+            if (value.ValueKind == JsonValueKind.Null)
+            {
+                return null;
+            }
+
+            var lowerBound = value.GetDateTime();
+
+            return dateInterval switch
+            {
+                // Add a random offset at the next lower level of granularity.
+                "year" => lowerBound.AddMonths(rng.Next(12)),
+                "quarter" => lowerBound.AddMonths(rng.Next(3)),
+                "month" => lowerBound.AddDays(rng.NextDouble() * DateTime.DaysInMonth(lowerBound.Year, lowerBound.Month)),
+                "day" => lowerBound.AddHours(rng.NextDouble() * 24),
+                "hour" => lowerBound.AddMinutes(rng.NextDouble() * 60),
+                "minute" => lowerBound.AddSeconds(rng.NextDouble() * 60),
+                "second" => lowerBound.AddMilliseconds(rng.NextDouble() * 1000),
+                _ => lowerBound,
+            };
+        }
+    }
+}


### PR DESCRIPTION
Simple datetime bucketing and synthesis for correlation analysis. 

Uses the single column analysis to deduce a suitable bucket size (not too large, not too noisy). 
Generates a sample from the bucket snapped to the next-smaller time interval. 
(For example: bucket is an hour wide -> generate random number between 0 and 60 minutes and add these to the hour). 