### PR TITLE
max length limit for text exploration

### DIFF
--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -209,8 +209,9 @@ namespace Explorer.Components
             foreach (var length in substringLengths)
             {
                 var hasRows = true;
-                for (var pos = 0; hasRows; pos += substringQueryColumnCount)
+                for (var pos = 0; hasRows && pos < options.TextColumnMaxExplorationLength; pos += substringQueryColumnCount)
                 {
+                    substringQueryColumnCount = Math.Min(substringQueryColumnCount, options.TextColumnMaxExplorationLength + 1 - pos);
                     var query = new TextColumnSubstring(pos, length, substringQueryColumnCount, length);
                     var sstrResult = await Context.Exec(query);
                     hasRows = false;

--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -80,9 +80,10 @@ namespace Explorer.Components
                 return null;
             }
 
+            var lengthDistribution = LengthDistribution.FromTupleEnum(textLengthDistributionResult.Distribution);
             var sampleValues = emailCheckerResult.IsEmail ?
-                await GenerateEmails(textLengthDistributionResult.Distribution, config) :
-                await GenerateStrings(textLengthDistributionResult.Distribution, config);
+                await GenerateEmails(lengthDistribution, config) :
+                await GenerateStrings(lengthDistribution, config);
             return new Result(sampleValues.ToList());
         }
 

--- a/src/explorer/Components/TextGeneratorComponent.cs
+++ b/src/explorer/Components/TextGeneratorComponent.cs
@@ -216,10 +216,13 @@ namespace Explorer.Components
                     hasRows = false;
                     foreach (var row in sstrResult.Rows)
                     {
-                        if (row.HasValue && !BannedWords.Contains(row.Value.ToUpperInvariant()))
+                        if (row.HasValue)
                         {
                             hasRows = true;
-                            substrings.Add(pos + row.Index, row.Value, row.Count);
+                            if (!BannedWords.Contains(row.Value.ToUpperInvariant()))
+                            {
+                                substrings.Add(pos + row.Index, row.Value, row.Count);
+                            }
                         }
                     }
                 }

--- a/src/explorer/Components/TextLengthDistribution.cs
+++ b/src/explorer/Components/TextLengthDistribution.cs
@@ -25,7 +25,7 @@ namespace Explorer.Components
             }
 
             yield return new UntypedMetric("text.length.values", result.Distribution
-                .Select(item => new { item.Value, item.Count })
+                .Select(item => new { Value = item.Length, item.Count })
                 .ToList());
 
             if (result.ValueCounts != null)
@@ -79,21 +79,22 @@ namespace Explorer.Components
         {
             internal Result(IList<(long, long)> distribution)
             {
-                Distribution = ValueWithCountList<long>.FromTupleEnum(distribution);
+                Distribution = distribution;
             }
 
             internal Result(IEnumerable<ValueWithCount<JsonElement>> distinctRows)
             {
                 ValueCounts = ValueCounts.Compute(distinctRows);
-                Distribution = ValueWithCountList<long>.FromTupleEnum(distinctRows
+                Distribution = distinctRows
                     .Where(r => r.HasValue)
                     .OrderBy(r => r.Value.GetInt32())
-                    .Select(r => (r.Value.GetInt64(), r.Count)));
+                    .Select(r => (r.Value.GetInt64(), r.Count))
+                    .ToList();
             }
 
             internal ValueCounts? ValueCounts { get; }
 
-            internal ValueWithCountList<long> Distribution { get; }
+            internal IList<(long Length, long Count)> Distribution { get; }
         }
     }
 }

--- a/src/explorer/ExplorerOptions.cs
+++ b/src/explorer/ExplorerOptions.cs
@@ -3,11 +3,12 @@ namespace Explorer
     public class ExplorerOptions
     {
         public const int DefaultSamplesToPublish = 20;
-        public const int DefaultSubstringQueryColumnCount = 5;
+        public const int DefaultSubstringQueryColumnCount = 16;
         public const int DefaultMaxCorrelationDepth = 2;
         public const bool DefaultMultiColumnEnabled = true;
         public const int DefaultDistinctValuesToPublish = 10;
         public const double DefaultTextColumnMinFactorForCategoricalSampling = 0.05;
+        public const int DefaultTextColumnMaxExplorationLength = 100;
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable multi-column correlation analysis.
@@ -50,5 +51,13 @@ namespace Explorer
         /// <see cref="DefaultTextColumnMinFactorForCategoricalSampling" />.</value>
         public double TextColumnMinFactorForCategoricalSampling { get; set; } =
             DefaultTextColumnMinFactorForCategoricalSampling;
+
+        /// <summary>
+        /// Gets or sets the maximum length limit for the exploration of substrings from non-categorical text columns.
+        /// </summary>
+        /// <value>The value should be bigger than 0.
+        /// Default value is <see cref="DefaultTextColumnMaxExplorationLength" />.
+        /// </value>
+        public int TextColumnMaxExplorationLength { get; set; } = DefaultTextColumnMaxExplorationLength;
     }
 }

--- a/tests/explorer.tests/TextColumnExplorerTests.cs
+++ b/tests/explorer.tests/TextColumnExplorerTests.cs
@@ -4,6 +4,7 @@ namespace Explorer.Tests
     using System.Linq;
 
     using Explorer.Components;
+    using Microsoft.Extensions.Options;
     using Xunit;
 
     public sealed class TextColumnExplorerTests : IClassFixture<ExplorerTestFixture>
@@ -20,21 +21,22 @@ namespace Explorer.Tests
         {
             using var scope = await testFixture.CreateTestScope("gda_banking", "loans", "status", this);
 
-            var textLenDistribution = new TextLengthDistribution() { Context = scope.Context };
+            var options = Options.Create(new ExplorerOptions());
+            var textLenDistribution = new TextLengthDistribution(options) { Context = scope.Context };
             var r = await textLenDistribution.ComputeIsolatorLengthDistribution();
             Assert.NotNull(r);
             var d0 = r!.Distribution;
             Assert.Single(d0);
-            Assert.Equal(1, d0[0].Value);
+            Assert.Equal(1, d0[0].Length);
 
             await scope.ResultTest<TextLengthDistribution, TextLengthDistribution.Result>(r =>
             {
                 Assert.NotNull(r);
                 var d1 = r!.Distribution;
                 Assert.Single(d1);
-                Assert.Equal(1, d1[0].Value);
+                Assert.Equal(1, d1[0].Length);
 
-                Assert.True(Math.Abs(d0[0].Count - d1[0].Count) < 0.01 * d0[0].Count);
+                Assert.True(Math.Abs(d0[0].Count - d1[0].Count) < 0.05 * d0[0].Count);
             });
         }
 
@@ -43,24 +45,25 @@ namespace Explorer.Tests
         {
             using var scope = await testFixture.CreateTestScope("gda_banking", "loans", "disp_type", this);
 
-            var textLenDistribution = new TextLengthDistribution() { Context = scope.Context };
+            var options = Options.Create(new ExplorerOptions());
+            var textLenDistribution = new TextLengthDistribution(options) { Context = scope.Context };
             var r = await textLenDistribution.ComputeIsolatorLengthDistribution();
             Assert.NotNull(r);
             var d0 = r!.Distribution;
             Assert.Equal(2, d0.Count);
-            Assert.Equal(5, d0[0].Value); // "OWNER"
-            Assert.Equal(9, d0[1].Value); // "DISPONENT"
+            Assert.Equal(5, d0[0].Length); // "OWNER"
+            Assert.Equal(9, d0[1].Length); // "DISPONENT"
 
             await scope.ResultTest<TextLengthDistribution, TextLengthDistribution.Result>(r =>
             {
                 Assert.NotNull(r);
                 var d1 = r!.Distribution;
                 Assert.Equal(2, d1.Count);
-                Assert.Equal(5, d1[0].Value); // "OWNER"
-                Assert.Equal(9, d1[1].Value); // "DISPONENT"
+                Assert.Equal(5, d1[0].Length); // "OWNER"
+                Assert.Equal(9, d1[1].Length); // "DISPONENT"
 
-                Assert.True(Math.Abs(d0[0].Count - d1[0].Count) < 0.01 * d0[0].Count);
-                Assert.True(Math.Abs(d0[1].Count - d1[1].Count) < 0.01 * d0[1].Count);
+                Assert.True(Math.Abs(d0[0].Count - d1[0].Count) < 0.05 * d0[0].Count);
+                Assert.True(Math.Abs(d0[1].Count - d1[1].Count) < 0.05 * d0[1].Count);
             });
         }
 


### PR DESCRIPTION
- added a maximum length limit for the exploration of substrings from non-categorical text columns
- fixed the value for "text.length.values" metric (publish the distribution instead of the list with cumulative sums)
- fixes #353