### PR TITLE
Require `columns` param to be a non-empty array.

### DIFF
--- a/src/explorer.api/Models/ExploreParams.cs
+++ b/src/explorer.api/Models/ExploreParams.cs
@@ -2,9 +2,11 @@
 
 namespace Explorer.Api.Models
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.ComponentModel.DataAnnotations;
     using System.Globalization;
+    using System.Linq;
 
     public class ExploreParams
     {
@@ -26,11 +28,28 @@ namespace Explorer.Api.Models
         [Required]
         public string Table { get; set; } = string.Empty;
 
-        [Required]
+        [NonEmpty]
         public ImmutableArray<string> Columns { get; set; } = ImmutableArray<string>.Empty;
 
         [Range(0, int.MaxValue, ErrorMessage = "Value for {0} must be greater or equal to {1}.")]
         public int? SamplesToPublish { get; set; }
+
+        [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false)]
+        private class NonEmptyAttribute : ValidationAttribute
+        {
+            public override object TypeId => base.TypeId;
+
+            public override bool RequiresValidationContext => base.RequiresValidationContext;
+
+            public override bool IsValid(object value) => value is IEnumerable<object> e && e.Any();
+
+            protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+            {
+                return IsValid(value)
+                    ? ValidationResult.Success
+                    : new ValidationResult($"Array '{validationContext.MemberName}' is required and cannot be empty.");
+            }
+        }
     }
 }
 

--- a/tests/explorer.api.tests/ApiTests.cs
+++ b/tests/explorer.api.tests/ApiTests.cs
@@ -95,10 +95,6 @@
         }
 
         [Fact]
-        public async Task SuccessWithResultNoColumns() => await SuccessWithResult(
-            new ExploreParams { DataSource = "gda_banking", Table = "loans", Columns = ImmutableArray<string>.Empty, });
-
-        [Fact]
         public async Task SuccessWithResultIntCategorical() => await SuccessWithResult(
             new ExploreParams { DataSource = "gda_banking", Table = "loans", Columns = ImmutableArray.Create("duration"), });
 
@@ -306,6 +302,7 @@
                 Assert.Contains("The ApiKey field is required.", content, StringComparison.InvariantCulture);
                 Assert.Contains("The DataSource field is required.", content, StringComparison.InvariantCulture);
                 Assert.Contains("The Table field is required.", content, StringComparison.InvariantCulture);
+                Assert.Contains("Array 'Columns' is required and cannot be empty.", content, StringComparison.InvariantCulture);
             });
         }
 
@@ -319,6 +316,7 @@
                 Assert.Contains("The ApiKey field is required.", content, StringComparison.InvariantCulture);
                 Assert.Contains("The DataSource field is required.", content, StringComparison.InvariantCulture);
                 Assert.Contains("The Table field is required.", content, StringComparison.InvariantCulture);
+                Assert.Contains("Array 'Columns' is required and cannot be empty.", content, StringComparison.InvariantCulture);
             });
         }
 


### PR DESCRIPTION
- Fixes #371  : Require column list to be non-empty.