### PR TITLE
Do not serialize decimals_count_distribution.

### DIFF
--- a/src/explorer.api/Startup.cs
+++ b/src/explorer.api/Startup.cs
@@ -2,7 +2,6 @@ namespace Explorer.Api
 {
     using Aircloak.JsonApi;
     using Explorer.Api.Authentication;
-    using Explorer.Api.Models;
     using Explorer.Components;
     using Explorer.Metrics;
     using Lamar;
@@ -31,7 +30,8 @@ namespace Explorer.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureContainer(ServiceRegistry services)
         {
-            services.AddControllers();
+            services.AddControllers().AddJsonOptions(options =>
+                options.JsonSerializerOptions.Converters.Add(new ExploreMetricConverter()));
             services.AddApiVersioning();
 
             const string ConfigSection = "Explorer";

--- a/src/explorer/Components/DistinctValuesComponent.cs
+++ b/src/explorer/Components/DistinctValuesComponent.cs
@@ -63,7 +63,10 @@ namespace Explorer.Components
             yield return new UntypedMetric(name: "distinct.value_count", metric: valueCounts.TotalCount);
             if (result.DecimalsCountDistribution != null)
             {
-                yield return new UntypedMetric(name: "distinct.decimals_count_distribution", metric: result.DecimalsCountDistribution);
+                yield return new UntypedMetric(
+                    name: "distinct.decimals_count_distribution",
+                    metric: result.DecimalsCountDistribution,
+                    invisible: true);
             }
         }
 

--- a/src/explorer/Components/DistributionPublishers/NumericDistribution.cs
+++ b/src/explorer/Components/DistributionPublishers/NumericDistribution.cs
@@ -49,6 +49,15 @@
 
         public double Generate(Random source) => distribution.Generate(source);
 
-        public int GenerateInt(Random source) => (int)Math.Round(distribution.Generate(source));
+        public int? GenerateInt(Random source)
+        {
+            var d = distribution.Generate(source);
+            if (double.IsFinite(d))
+            {
+                return Convert.ToInt32(d);
+            }
+
+            return null;
+        }
     }
 }

--- a/src/explorer/Metrics/ExploreMetric.cs
+++ b/src/explorer/Metrics/ExploreMetric.cs
@@ -9,7 +9,8 @@ namespace Explorer.Metrics
         [JsonPropertyName("value")]
         public object Metric { get; }
 
-        [JsonIgnore]
         public int Priority { get; }
+
+        public bool Invisible { get; }
     }
 }

--- a/src/explorer/Metrics/ExploreMetricConverter.cs
+++ b/src/explorer/Metrics/ExploreMetricConverter.cs
@@ -1,0 +1,32 @@
+namespace Explorer.Metrics
+{
+    using System;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    public class ExploreMetricConverter : JsonConverter<ExploreMetric>
+    {
+        public override ExploreMetric Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new InvalidOperationException("Don't try to read an ExploreMetric!");
+        }
+
+        public override void Write(Utf8JsonWriter writer, ExploreMetric value, JsonSerializerOptions options)
+        {
+            if (value.Invisible)
+            {
+                // Do nothing, it's invisible.
+                return;
+            }
+
+            JsonSerializer.Serialize(
+                writer,
+                new
+                {
+                    name = value.Name,
+                    value = value.Metric,
+                },
+                options);
+        }
+    }
+}

--- a/src/explorer/Metrics/UntypedMetric.cs
+++ b/src/explorer/Metrics/UntypedMetric.cs
@@ -2,13 +2,15 @@ namespace Explorer.Metrics
 {
     using System.Text.Json.Serialization;
 
+    [JsonConverter(typeof(ExploreMetricConverter))]
     public class UntypedMetric : ExploreMetric
     {
-        public UntypedMetric(string name, object metric, int priority = 0)
+        public UntypedMetric(string name, object metric, int priority = 0, bool invisible = false)
         {
             Name = name;
             Metric = metric;
             Priority = priority;
+            Invisible = invisible;
         }
 
         public string Name { get; }
@@ -17,5 +19,8 @@ namespace Explorer.Metrics
 
         [JsonIgnore]
         public int Priority { get; }
+
+        [JsonIgnore]
+        public bool Invisible { get; }
     }
 }


### PR DESCRIPTION
The underlying object can't be serialized, this causes an exception.

Also, guard against NaN values when generating random ints from a `NumericalDistribution`.

Fixes #383 